### PR TITLE
Add MPT cache support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 .vscode
 
 .idea/
+*.log

--- a/core/statecache/blockcache.go
+++ b/core/statecache/blockcache.go
@@ -117,6 +117,12 @@ func (pcc *BlockCache) remove(key string) {
 
 // Commit moves the values from the pre-commit cache to the main cache
 func (pcc *BlockCache) Commit() {
+	_, ok := pcc.main.hashCache.Get(pcc.blockHash)
+	if !ok {
+		// block already committed
+		return
+	}
+
 	pcc.mu.Lock()
 	defer pcc.mu.Unlock()
 

--- a/core/statecache/blockcache.go
+++ b/core/statecache/blockcache.go
@@ -2,11 +2,6 @@ package statecache
 
 import (
 	"sync"
-	"time"
-
-	"github.com/0chain/common/core/logging"
-	lru "github.com/hashicorp/golang-lru"
-	"go.uber.org/zap"
 )
 
 type BlockCacher interface {
@@ -117,49 +112,51 @@ func (pcc *BlockCache) remove(key string) {
 
 // Commit moves the values from the pre-commit cache to the main cache
 func (pcc *BlockCache) Commit() {
+	pcc.main.commit(pcc)
+
 	// _, ok := pcc.main.hashCache.Get(pcc.blockHash)
 	// if !ok {
 	// 	// block already committed
 	// 	return
 	// }
 
-	pcc.mu.Lock()
-	defer pcc.mu.Unlock()
+	// pcc.mu.Lock()
+	// defer pcc.mu.Unlock()
 
-	// pcc.main.mu.Lock()
+	// // pcc.main.mu.Lock()
 
-	// pcc.main.shift(pcc.prevBlockHash, pcc.blockHash)
-	ts := time.Now()
-	for key, v := range pcc.cache {
-		bvsi, ok := pcc.main.cache.Get(key)
-		if !ok {
-			var err error
-			bvsi, err = lru.New(200)
-			if err != nil {
-				panic(err)
-			}
-		}
+	// // pcc.main.shift(pcc.prevBlockHash, pcc.blockHash)
+	// ts := time.Now()
+	// for key, v := range pcc.cache {
+	// 	bvsi, ok := pcc.main.cache.Get(key)
+	// 	if !ok {
+	// 		var err error
+	// 		bvsi, err = lru.New(200)
+	// 		if err != nil {
+	// 			panic(err)
+	// 		}
+	// 	}
 
-		bvs := bvsi.(*lru.Cache)
+	// 	bvs := bvsi.(*lru.Cache)
 
-		if v.data != nil {
-			v.data = v.data.Clone()
-		}
-		bvs.Add(pcc.blockHash, v)
+	// 	if v.data != nil {
+	// 		v.data = v.data.Clone()
+	// 	}
+	// 	bvs.Add(pcc.blockHash, v)
 
-		pcc.main.cache.Add(key, bvs)
+	// 	pcc.main.cache.Add(key, bvs)
 
-		// logging.Logger.Debug("block cache commit",
-		// zap.String("key", key),
-		// zap.String("block", pcc.blockHash),
-		// zap.Int64("round", v.round),
-		// zap.Bool("deleted", v.deleted))
-	}
+	// 	// logging.Logger.Debug("block cache commit",
+	// 	// zap.String("key", key),
+	// 	// zap.String("block", pcc.blockHash),
+	// 	// zap.Int64("round", v.round),
+	// 	// zap.Bool("deleted", v.deleted))
+	// }
 
-	// pcc.main.mu.Unlock()
-	pcc.main.commitRound(pcc.round, pcc.prevBlockHash, pcc.blockHash)
+	// // pcc.main.mu.Unlock()
+	// pcc.main.commitRound(pcc.round, pcc.prevBlockHash, pcc.blockHash)
 
-	// Clear the pre-commit cache
-	pcc.cache = make(map[string]valueNode)
-	logging.Logger.Debug("statecache - commit", zap.String("block", pcc.blockHash), zap.Any("duration", time.Since(ts)))
+	// // Clear the pre-commit cache
+	// pcc.cache = make(map[string]valueNode)
+	// logging.Logger.Debug("statecache - commit", zap.String("block", pcc.blockHash), zap.Any("duration", time.Since(ts)))
 }

--- a/core/statecache/blockcache.go
+++ b/core/statecache/blockcache.go
@@ -22,7 +22,7 @@ type BlockCacher interface {
 // Call `Commit()` method to merge
 // the changes to the StateCache when the block is executed.
 type BlockCache struct {
-	mu            sync.RWMutex
+	mu            sync.Mutex
 	cache         map[string]valueNode
 	main          *StateCache
 	blockHash     string
@@ -75,8 +75,8 @@ func (pcc *BlockCache) setValue(key string, v valueNode) {
 
 // Get returns the value with the given key
 func (pcc *BlockCache) Get(key string) (Value, bool) {
-	pcc.mu.RLock()
-	defer pcc.mu.RUnlock()
+	pcc.mu.Lock()
+	defer pcc.mu.Unlock()
 
 	// Check the cache first
 	value, ok := pcc.cache[key]

--- a/core/statecache/blockcache.go
+++ b/core/statecache/blockcache.go
@@ -2,8 +2,11 @@ package statecache
 
 import (
 	"sync"
+	"time"
 
+	"github.com/0chain/common/core/logging"
 	lru "github.com/hashicorp/golang-lru"
+	"go.uber.org/zap"
 )
 
 type BlockCacher interface {
@@ -117,8 +120,9 @@ func (pcc *BlockCache) Commit() {
 
 	// pcc.main.mu.Lock()
 
-	pcc.main.shift(pcc.prevBlockHash, pcc.blockHash)
+	// pcc.main.shift(pcc.prevBlockHash, pcc.blockHash)
 
+	ts := time.Now()
 	for key, v := range pcc.cache {
 		bvsi, ok := pcc.main.cache.Get(key)
 		if !ok {
@@ -149,4 +153,5 @@ func (pcc *BlockCache) Commit() {
 
 	// Clear the pre-commit cache
 	pcc.cache = make(map[string]valueNode)
+	logging.Logger.Debug("statecache - commit", zap.Any("duration", time.Since(ts)))
 }

--- a/core/statecache/blockcache.go
+++ b/core/statecache/blockcache.go
@@ -92,7 +92,20 @@ func (pcc *BlockCache) Get(key string) (Value, bool) {
 		return nil, false
 	}
 
-	return pcc.main.Get(key, pcc.prevBlockHash)
+	v, ok := pcc.main.Get(key, pcc.prevBlockHash)
+	if ok {
+		// load the value from the state cache and store it in the block cache
+		vn := valueNode{
+			data:          v,
+			round:         pcc.round,
+			prevBlockHash: pcc.prevBlockHash,
+		}
+
+		pcc.cache[key] = vn
+		return v, true
+	}
+
+	return nil, false
 }
 
 // Remove marks the value with the given key as deleted in the pre-commit cache

--- a/core/statecache/blockcache.go
+++ b/core/statecache/blockcache.go
@@ -123,6 +123,10 @@ func (pcc *BlockCache) addStats(hit, miss int64) {
 	atomic.AddInt64(&pcc.miss, miss)
 }
 
+func (pcc *BlockCache) Stats() (hit, miss int64) {
+	return atomic.LoadInt64(&pcc.hits), atomic.LoadInt64(&pcc.miss)
+}
+
 // Commit moves the values from the pre-commit cache to the main cache
 func (pcc *BlockCache) Commit() {
 	pcc.main.commit(pcc)

--- a/core/statecache/blockcache.go
+++ b/core/statecache/blockcache.go
@@ -117,11 +117,11 @@ func (pcc *BlockCache) remove(key string) {
 
 // Commit moves the values from the pre-commit cache to the main cache
 func (pcc *BlockCache) Commit() {
-	_, ok := pcc.main.hashCache.Get(pcc.blockHash)
-	if !ok {
-		// block already committed
-		return
-	}
+	// _, ok := pcc.main.hashCache.Get(pcc.blockHash)
+	// if !ok {
+	// 	// block already committed
+	// 	return
+	// }
 
 	pcc.mu.Lock()
 	defer pcc.mu.Unlock()
@@ -161,5 +161,5 @@ func (pcc *BlockCache) Commit() {
 
 	// Clear the pre-commit cache
 	pcc.cache = make(map[string]valueNode)
-	logging.Logger.Debug("statecache - commit", zap.Any("duration", time.Since(ts)))
+	logging.Logger.Debug("statecache - commit", zap.String("block", pcc.blockHash), zap.Any("duration", time.Since(ts)))
 }

--- a/core/statecache/blockcache.go
+++ b/core/statecache/blockcache.go
@@ -53,9 +53,7 @@ func (pcc *BlockCache) Set(key string, e Value) {
 	pcc.mu.Lock()
 
 	pcc.cache[key] = valueNode{
-		data:          e.Clone(),
-		round:         pcc.round,
-		prevBlockHash: pcc.prevBlockHash,
+		data: e.Clone(),
 	}
 	pcc.mu.Unlock()
 }
@@ -69,7 +67,6 @@ func (pcc *BlockCache) setValue(key string, v valueNode) {
 	defer pcc.mu.Unlock()
 
 	v.data = v.data.Clone()
-	v.prevBlockHash = pcc.prevBlockHash
 	pcc.cache[key] = v
 }
 
@@ -92,20 +89,22 @@ func (pcc *BlockCache) Get(key string) (Value, bool) {
 		return nil, false
 	}
 
-	v, ok := pcc.main.Get(key, pcc.prevBlockHash)
-	if ok {
-		// load the value from the state cache and store it in the block cache
-		vn := valueNode{
-			data:          v,
-			round:         pcc.round,
-			prevBlockHash: pcc.prevBlockHash,
-		}
+	return pcc.main.Get(key, pcc.prevBlockHash)
 
-		pcc.cache[key] = vn
-		return v, true
-	}
+	// v, ok := pcc.main.Get(key, pcc.prevBlockHash)
+	// if ok {
+	// 	// load the value from the state cache and store it in the block cache
+	// 	vn := valueNode{
+	// 		data:          v,
+	// 		round:         pcc.round,
+	// 		prevBlockHash: pcc.prevBlockHash,
+	// 	}
 
-	return nil, false
+	// 	pcc.cache[key] = vn
+	// 	return v, true
+	// }
+
+	// return nil, false
 }
 
 // Remove marks the value with the given key as deleted in the pre-commit cache
@@ -121,7 +120,6 @@ func (pcc *BlockCache) remove(key string) {
 	} else {
 		pcc.cache[key] = valueNode{
 			deleted: true,
-			round:   pcc.round,
 		}
 	}
 }

--- a/core/statecache/blockcache.go
+++ b/core/statecache/blockcache.go
@@ -127,7 +127,7 @@ func (pcc *BlockCache) Commit() {
 		bvsi, ok := pcc.main.cache.Get(key)
 		if !ok {
 			var err error
-			bvsi, err = lru.New(10 * 1024)
+			bvsi, err = lru.New(1024)
 			if err != nil {
 				panic(err)
 			}

--- a/core/statecache/blockcache.go
+++ b/core/statecache/blockcache.go
@@ -127,6 +127,14 @@ func (pcc *BlockCache) Stats() (hit, miss int64) {
 	return atomic.LoadInt64(&pcc.hits), atomic.LoadInt64(&pcc.miss)
 }
 
+// SetBlockHash sets the block hash, which is used after miners generating the block.
+// miners generator does not know the block hash until the block is generated.
+func (pcc *BlockCache) SetBlockHash(hash string) {
+	pcc.mu.Lock()
+	pcc.blockHash = hash
+	pcc.mu.Unlock()
+}
+
 // Commit moves the values from the pre-commit cache to the main cache
 func (pcc *BlockCache) Commit() {
 	pcc.main.commit(pcc)

--- a/core/statecache/blockcache.go
+++ b/core/statecache/blockcache.go
@@ -2,6 +2,9 @@ package statecache
 
 import (
 	"sync"
+
+	"github.com/0chain/common/core/logging"
+	"go.uber.org/zap"
 )
 
 type BlockCacher interface {
@@ -80,12 +83,13 @@ func (pcc *BlockCache) Get(key string) (Value, bool) {
 	value, ok := pcc.cache[key]
 	if ok && !value.deleted {
 		// logging.Logger.Debug("block cache get", zap.String("key", key))
-		return value.data.Clone(), ok
+		return value.data.Clone(), true
 	}
 
 	// Should not return deleted value
 	if ok && value.deleted {
 		// logging.Logger.Debug("block cache get - deleted", zap.String("key", key))
+		logging.Logger.Debug("block state cache - deleted", zap.String("block", pcc.blockHash))
 		return nil, false
 	}
 

--- a/core/statecache/blockcache.go
+++ b/core/statecache/blockcache.go
@@ -2,6 +2,7 @@ package statecache
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/0chain/common/core/logging"
 	"go.uber.org/zap"
@@ -12,6 +13,7 @@ type BlockCacher interface {
 	Round() int64
 	Commit()
 	setValue(key string, v valueNode)
+	addStats(hit, miss int64)
 }
 
 // BlockCache is a pre commit cache for all changes in a block.
@@ -31,6 +33,8 @@ type BlockCache struct {
 	blockHash     string
 	prevBlockHash string
 	round         int64
+	hits          int64
+	miss          int64
 }
 
 type Block struct {
@@ -112,6 +116,11 @@ func (pcc *BlockCache) remove(key string) {
 			round:   pcc.round,
 		}
 	}
+}
+
+func (pcc *BlockCache) addStats(hit, miss int64) {
+	atomic.AddInt64(&pcc.hits, hit)
+	atomic.AddInt64(&pcc.miss, miss)
 }
 
 // Commit moves the values from the pre-commit cache to the main cache

--- a/core/statecache/blockcache.go
+++ b/core/statecache/blockcache.go
@@ -2,9 +2,6 @@ package statecache
 
 import (
 	"sync"
-
-	"github.com/0chain/common/core/logging"
-	"go.uber.org/zap"
 )
 
 type BlockCacher interface {
@@ -124,11 +121,11 @@ func (pcc *BlockCache) Commit() {
 			pcc.main.cache[key] = make(map[string]valueNode)
 		}
 		v.data = v.data.Clone()
-		logging.Logger.Debug("block cache commit",
-			zap.String("key", key),
-			zap.String("block", pcc.blockHash),
-			zap.Int64("round", v.round),
-			zap.Bool("deleted", v.deleted))
+		// logging.Logger.Debug("block cache commit",
+		// zap.String("key", key),
+		// zap.String("block", pcc.blockHash),
+		// zap.Int64("round", v.round),
+		// zap.Bool("deleted", v.deleted))
 		pcc.main.cache[key][pcc.blockHash] = v
 	}
 

--- a/core/statecache/blockcache.go
+++ b/core/statecache/blockcache.go
@@ -19,11 +19,6 @@ type BlockCacher interface {
 // BlockCache is a pre commit cache for all changes in a block.
 // This is mainly for caching values in current block when executing blocks.
 //
-// Querying from this BlockCache will only return value from current block, and previous block if not found
-// in current block. That means if there are no changes happen in current block yet,
-// querying the value from current block hash will return nothing even the StateCache does has the value.
-// So please remember to use QueryBlockCache to get values from current block.
-//
 // Call `Commit()` method to merge
 // the changes to the StateCache when the block is executed.
 type BlockCache struct {
@@ -83,7 +78,7 @@ func (pcc *BlockCache) Get(key string) (Value, bool) {
 	pcc.mu.RLock()
 	defer pcc.mu.RUnlock()
 
-	// Check the pre-commit cache first
+	// Check the cache first
 	value, ok := pcc.cache[key]
 	if ok && !value.deleted {
 		// logging.Logger.Debug("block cache get", zap.String("key", key))
@@ -138,50 +133,4 @@ func (pcc *BlockCache) SetBlockHash(hash string) {
 // Commit moves the values from the pre-commit cache to the main cache
 func (pcc *BlockCache) Commit() {
 	pcc.main.commit(pcc)
-
-	// _, ok := pcc.main.hashCache.Get(pcc.blockHash)
-	// if !ok {
-	// 	// block already committed
-	// 	return
-	// }
-
-	// pcc.mu.Lock()
-	// defer pcc.mu.Unlock()
-
-	// // pcc.main.mu.Lock()
-
-	// // pcc.main.shift(pcc.prevBlockHash, pcc.blockHash)
-	// ts := time.Now()
-	// for key, v := range pcc.cache {
-	// 	bvsi, ok := pcc.main.cache.Get(key)
-	// 	if !ok {
-	// 		var err error
-	// 		bvsi, err = lru.New(200)
-	// 		if err != nil {
-	// 			panic(err)
-	// 		}
-	// 	}
-
-	// 	bvs := bvsi.(*lru.Cache)
-
-	// 	if v.data != nil {
-	// 		v.data = v.data.Clone()
-	// 	}
-	// 	bvs.Add(pcc.blockHash, v)
-
-	// 	pcc.main.cache.Add(key, bvs)
-
-	// 	// logging.Logger.Debug("block cache commit",
-	// 	// zap.String("key", key),
-	// 	// zap.String("block", pcc.blockHash),
-	// 	// zap.Int64("round", v.round),
-	// 	// zap.Bool("deleted", v.deleted))
-	// }
-
-	// // pcc.main.mu.Unlock()
-	// pcc.main.commitRound(pcc.round, pcc.prevBlockHash, pcc.blockHash)
-
-	// // Clear the pre-commit cache
-	// pcc.cache = make(map[string]valueNode)
-	// logging.Logger.Debug("statecache - commit", zap.String("block", pcc.blockHash), zap.Any("duration", time.Since(ts)))
 }

--- a/core/statecache/blockcache.go
+++ b/core/statecache/blockcache.go
@@ -80,13 +80,13 @@ func (pcc *BlockCache) Get(key string) (Value, bool) {
 	// Check the pre-commit cache first
 	value, ok := pcc.cache[key]
 	if ok && !value.deleted {
-		logging.Logger.Debug("block cache get", zap.String("key", key))
+		// logging.Logger.Debug("block cache get", zap.String("key", key))
 		return value.data.Clone(), ok
 	}
 
 	// Should not return deleted value
 	if ok && value.deleted {
-		logging.Logger.Debug("block cache get - deleted", zap.String("key", key))
+		// logging.Logger.Debug("block cache get - deleted", zap.String("key", key))
 		return nil, false
 	}
 

--- a/core/statecache/blockcache.go
+++ b/core/statecache/blockcache.go
@@ -1,0 +1,139 @@
+package statecache
+
+import (
+	"sync"
+
+	"github.com/0chain/common/core/logging"
+	"go.uber.org/zap"
+)
+
+type BlockCacher interface {
+	Get(key string) (Value, bool)
+	Round() int64
+	Commit()
+	setValue(key string, v valueNode)
+}
+
+// BlockCache is a pre commit cache for all changes in a block.
+// This is mainly for caching values in current block when executing blocks.
+//
+// Querying from this BlockCache will only return value from current block, and previous block if not found
+// in current block. That means if there are no changes happen in current block yet,
+// querying the value from current block hash will return nothing even the StateCache does has the value.
+// So please remember to use QueryBlockCache to get values from current block.
+//
+// Call `Commit()` method to merge
+// the changes to the StateCache when the block is executed.
+type BlockCache struct {
+	mu            sync.RWMutex
+	cache         map[string]valueNode
+	main          *StateCache
+	blockHash     string
+	prevBlockHash string
+	round         int64
+}
+
+type Block struct {
+	Round    int64  // round number when this block cache is created
+	Hash     string // block hash
+	PrevHash string // previous hash of the block
+}
+
+func NewBlockCache(main *StateCache, b Block) *BlockCache {
+	return &BlockCache{
+		cache:         make(map[string]valueNode),
+		main:          main,
+		blockHash:     b.Hash,
+		prevBlockHash: b.PrevHash,
+		round:         b.Round,
+	}
+}
+
+// Set sets the value with the given key in the pre-commit cache
+func (pcc *BlockCache) Set(key string, e Value) {
+	pcc.mu.Lock()
+	defer pcc.mu.Unlock()
+
+	pcc.cache[key] = valueNode{
+		data:  e.Clone(),
+		round: pcc.round,
+	}
+}
+
+func (pcc *BlockCache) Round() int64 {
+	return pcc.round
+}
+
+func (pcc *BlockCache) setValue(key string, v valueNode) {
+	pcc.mu.Lock()
+	defer pcc.mu.Unlock()
+
+	v.data = v.data.Clone()
+	pcc.cache[key] = v
+}
+
+// Get returns the value with the given key
+func (pcc *BlockCache) Get(key string) (Value, bool) {
+	pcc.mu.RLock()
+	defer pcc.mu.RUnlock()
+
+	// Check the pre-commit cache first
+	value, ok := pcc.cache[key]
+	if ok && !value.deleted {
+		logging.Logger.Debug("block cache get", zap.String("key", key))
+		return value.data.Clone(), ok
+	}
+
+	// Should not return deleted value
+	if ok && value.deleted {
+		logging.Logger.Debug("block cache get - deleted", zap.String("key", key))
+		return nil, false
+	}
+
+	return pcc.main.Get(key, pcc.prevBlockHash)
+}
+
+// Remove marks the value with the given key as deleted in the pre-commit cache
+func (pcc *BlockCache) remove(key string) {
+	pcc.mu.Lock()
+	defer pcc.mu.Unlock()
+
+	value, ok := pcc.cache[key]
+	if ok {
+		value.deleted = true
+		pcc.cache[key] = value
+		return
+	} else {
+		pcc.cache[key] = valueNode{
+			deleted: true,
+			round:   pcc.round,
+		}
+	}
+}
+
+// Commit moves the values from the pre-commit cache to the main cache
+func (pcc *BlockCache) Commit() {
+	pcc.mu.Lock()
+	defer pcc.mu.Unlock()
+
+	pcc.main.mu.Lock()
+	pcc.main.shift(pcc.prevBlockHash, pcc.blockHash)
+
+	for key, v := range pcc.cache {
+		if _, ok := pcc.main.cache[key]; !ok {
+			pcc.main.cache[key] = make(map[string]valueNode)
+		}
+		v.data = v.data.Clone()
+		logging.Logger.Debug("block cache commit",
+			zap.String("key", key),
+			zap.String("block", pcc.blockHash),
+			zap.Int64("round", v.round),
+			zap.Bool("deleted", v.deleted))
+		pcc.main.cache[key][pcc.blockHash] = v
+	}
+
+	pcc.main.mu.Unlock()
+
+	// Clear the pre-commit cache
+	pcc.cache = make(map[string]valueNode)
+}

--- a/core/statecache/queryblockcache.go
+++ b/core/statecache/queryblockcache.go
@@ -31,3 +31,6 @@ func (qbc *QueryBlockCache) Commit() {
 func (*QueryBlockCache) setValue(key string, v valueNode) {
 	panic("setValue should not be called on QueryBlockCache")
 }
+
+func (*QueryBlockCache) addStats(hit, miss int64) {
+}

--- a/core/statecache/queryblockcache.go
+++ b/core/statecache/queryblockcache.go
@@ -1,0 +1,33 @@
+package statecache
+
+// QueryBlockCache is a read-only cache for querying values from the current block.
+type QueryBlockCache struct {
+	sc        *StateCache
+	blockHash string
+}
+
+// NewQueryBlockCache creates a new QueryBlockCache instance.
+func NewQueryBlockCache(sc *StateCache, blockHash string) *QueryBlockCache {
+	return &QueryBlockCache{
+		sc:        sc,
+		blockHash: blockHash,
+	}
+}
+
+// Get returns the value with the given key from the current block cache.
+func (qbc *QueryBlockCache) Get(key string) (Value, bool) {
+	return qbc.sc.Get(key, qbc.blockHash)
+}
+
+func (qbc *QueryBlockCache) Round() int64 {
+	return 0
+}
+
+func (qbc *QueryBlockCache) Commit() {
+	panic("Commit should not be called on QueryBlockCache")
+}
+
+// setValue implements BlockCacher.
+func (*QueryBlockCache) setValue(key string, v valueNode) {
+	panic("setValue should not be called on QueryBlockCache")
+}

--- a/core/statecache/statecache.go
+++ b/core/statecache/statecache.go
@@ -124,11 +124,17 @@ func (sc *StateCache) commit(bc *BlockCache) {
 	sc.commitRound(bc.round, bc.prevBlockHash, bc.blockHash)
 
 	sc.hits += bc.hits
-	sc.miss += bc.hits
+	sc.miss += bc.miss
 
 	// Clear the pre-commit cache
 	bc.cache = make(map[string]valueNode)
-	logging.Logger.Debug("statecache - commit", zap.String("block", bc.blockHash), zap.Any("duration", time.Since(ts)))
+	logging.Logger.Debug("statecache - commit",
+		zap.String("block", bc.blockHash),
+		zap.Int64("bc_hits", bc.hits),
+		zap.Int64("bc_miss", bc.miss),
+		zap.Int64("sc_hits", sc.hits),
+		zap.Int64("sc_miss", sc.miss),
+		zap.Any("duration", time.Since(ts)))
 }
 
 // Get returns the value with the given key and block hash

--- a/core/statecache/statecache.go
+++ b/core/statecache/statecache.go
@@ -133,7 +133,7 @@ func (sc *StateCache) Get(key, blockHash string) (Value, bool) {
 
 	blockValues, ok := sc.cache.Get(key)
 	if !ok {
-		// logging.Logger.Debug("state cache get - not found", zap.String("key", key))
+		logging.Logger.Debug("state cache get - key not found", zap.String("key", key))
 		return nil, false
 	}
 

--- a/core/statecache/statecache.go
+++ b/core/statecache/statecache.go
@@ -123,8 +123,8 @@ func (sc *StateCache) commit(bc *BlockCache) {
 
 	sc.commitRound(bc.round, bc.prevBlockHash, bc.blockHash)
 
-	bc.hits += bc.hits
-	bc.miss += bc.hits
+	sc.hits += bc.hits
+	sc.miss += bc.hits
 
 	// Clear the pre-commit cache
 	bc.cache = make(map[string]valueNode)

--- a/core/statecache/statecache.go
+++ b/core/statecache/statecache.go
@@ -161,7 +161,7 @@ func (sc *StateCache) Get(key, blockHash string) (Value, bool) {
 		return nil, false
 	}
 
-	oldBlockHash := blockHash
+	// oldBlockHash := blockHash
 
 	var count int
 	for {
@@ -189,19 +189,19 @@ func (sc *StateCache) Get(key, blockHash string) (Value, bool) {
 		v := vv.(valueNode)
 
 		// save into current block cache only when it's 20 rounds behind
-		if count >= 20 {
-			bvsi, err := lru.New(200)
-			if err != nil {
-				panic(err)
-			}
+		// if count >= 20 {
+		// 	bvsi, err := lru.New(200)
+		// 	if err != nil {
+		// 		panic(err)
+		// 	}
 
-			bvsi.Add(oldBlockHash, v)
+		// 	bvsi.Add(oldBlockHash, v)
 
-			sc.cache.Add(key, bvsi)
-			logging.Logger.Debug("state cache - migrate from previous block",
-				zap.String("key", key),
-				zap.Int("depth", count))
-		}
+		// 	sc.cache.Add(key, bvsi)
+		// 	logging.Logger.Debug("state cache - migrate from previous block",
+		// 		zap.String("key", key),
+		// 		zap.Int("depth", count))
+		// }
 
 		if v.deleted {
 			logging.Logger.Debug("state cache - is deleted")

--- a/core/statecache/statecache.go
+++ b/core/statecache/statecache.go
@@ -73,22 +73,22 @@ func (sc *StateCache) Get(key, blockHash string) (Value, bool) {
 
 	blockValues, ok := sc.cache[key]
 	if !ok {
-		logging.Logger.Debug("state cache get - not found", zap.String("key", key))
+		// logging.Logger.Debug("state cache get - not found", zap.String("key", key))
 		return nil, false
 	}
 
 	v, ok := blockValues[blockHash]
 	if !ok {
-		logging.Logger.Debug("state cache get - key found, value not found", zap.String("key", key))
+		// logging.Logger.Debug("state cache get - key found, value not found", zap.String("key", key))
 		return nil, false
 	}
 
 	if !v.deleted {
-		logging.Logger.Debug("state cache get", zap.String("key", key))
+		// logging.Logger.Debug("state cache get", zap.String("key", key))
 		return v.data.Clone(), true
 	}
 
-	logging.Logger.Debug("state cache get - deleted", zap.String("key", key))
+	// logging.Logger.Debug("state cache get - deleted", zap.String("key", key))
 	return nil, false
 }
 

--- a/core/statecache/statecache.go
+++ b/core/statecache/statecache.go
@@ -157,6 +157,7 @@ func (sc *StateCache) Get(key, blockHash string) (Value, bool) {
 		prevHash, ok := sc.hashCache.Get(blockHash)
 		if !ok {
 			// could not find previous hash
+			logging.Logger.Debug("state cache - see gap", zap.String("block", blockHash))
 			return nil, false
 		}
 
@@ -165,6 +166,7 @@ func (sc *StateCache) Get(key, blockHash string) (Value, bool) {
 		if !ok {
 			// stop if the value is not found in previous maxHisDepth rounds
 			if count >= sc.maxHisDepth {
+				logging.Logger.Debug("state cache - reach max depth", zap.String("block", blockHash))
 				return nil, false
 			}
 
@@ -173,6 +175,7 @@ func (sc *StateCache) Get(key, blockHash string) (Value, bool) {
 
 		v := vv.(valueNode)
 		if v.deleted {
+			logging.Logger.Debug("state cache - is deleted")
 			return nil, false
 		}
 

--- a/core/statecache/statecache.go
+++ b/core/statecache/statecache.go
@@ -71,7 +71,7 @@ func NewStateCache() *StateCache {
 		panic(err)
 	}
 
-	maxHisDepth := 100
+	maxHisDepth := 2000
 	hCache, err := lru.New(maxHisDepth)
 	if err != nil {
 		panic(err)

--- a/core/statecache/statecache.go
+++ b/core/statecache/statecache.go
@@ -61,6 +61,8 @@ type StateCache struct {
 	cache       *lru.Cache
 	hashCache   *lru.Cache
 	lock        sync.Mutex
+	hits        int64
+	miss        int64
 }
 
 func NewStateCache() *StateCache {
@@ -120,6 +122,9 @@ func (sc *StateCache) commit(bc *BlockCache) {
 	}
 
 	sc.commitRound(bc.round, bc.prevBlockHash, bc.blockHash)
+
+	bc.hits += bc.hits
+	bc.miss += bc.hits
 
 	// Clear the pre-commit cache
 	bc.cache = make(map[string]valueNode)
@@ -190,4 +195,11 @@ func (sc *StateCache) Remove(key string) {
 
 	sc.cache.Remove(key)
 	// delete(sc.cache, key)
+}
+
+func (sc *StateCache) Stats() (hits int64, miss int64) {
+	sc.lock.Lock()
+	hits, miss = sc.hits, sc.miss
+	sc.lock.Unlock()
+	return
 }

--- a/core/statecache/statecache.go
+++ b/core/statecache/statecache.go
@@ -1,8 +1,6 @@
 package statecache
 
 import (
-	"sync"
-
 	lru "github.com/hashicorp/golang-lru"
 )
 
@@ -54,12 +52,9 @@ type valueNode struct {
 }
 
 type StateCache struct {
-	mu              sync.RWMutex
-	lastBreakRound  int64
-	lastCommitRound int64
-	// cache map[string]map[string]valueNode
-	cache     *lru.Cache
-	hashCache *lru.Cache
+	maxHisDepth int
+	cache       *lru.Cache
+	hashCache   *lru.Cache
 }
 
 func NewStateCache() *StateCache {
@@ -68,28 +63,20 @@ func NewStateCache() *StateCache {
 		panic(err)
 	}
 
-	hCache, err := lru.New(100)
+	maxHisDepth := 100
+	hCache, err := lru.New(maxHisDepth)
 	if err != nil {
 		panic(err)
 	}
 
 	return &StateCache{
-		// cache: make(map[string]map[string]valueNode),
-		cache:     cache,
-		hashCache: hCache,
+		maxHisDepth: maxHisDepth,
+		cache:       cache,
+		hashCache:   hCache,
 	}
 }
 
 func (sc *StateCache) commitRound(round int64, prevHash, blockHash string) {
-	sc.mu.Lock()
-	// update the lastCommitRound and lastBreakRound only when round is greater than lastCommitRound
-	// this is because the commitRound could happen for old rounds
-	if round > sc.lastCommitRound && sc.lastCommitRound+1 != round {
-		sc.lastBreakRound = round // any valueNode with Round < lastBreakRound is stale
-		sc.lastCommitRound = round
-	}
-
-	sc.mu.Unlock()
 	sc.hashCache.Add(blockHash, prevHash)
 }
 
@@ -130,8 +117,8 @@ func (sc *StateCache) Get(key, blockHash string) (Value, bool) {
 		blockHash = prevHash.(string)
 		vv, ok = bvs.Get(blockHash)
 		if !ok {
-			// break if the value is not found in previous 100 rounds
-			if count >= 100 {
+			// stop if the value is not found in previous maxHisDepth rounds
+			if count >= sc.maxHisDepth {
 				return nil, false
 			}
 
@@ -139,14 +126,6 @@ func (sc *StateCache) Get(key, blockHash string) (Value, bool) {
 		}
 
 		v := vv.(valueNode)
-		sc.mu.Lock()
-		if v.round < sc.lastBreakRound {
-			sc.mu.Unlock()
-			// break if value round is less than last break round
-			return nil, false
-		}
-		sc.mu.Unlock()
-
 		if v.deleted {
 			return nil, false
 		}
@@ -154,65 +133,6 @@ func (sc *StateCache) Get(key, blockHash string) (Value, bool) {
 		return v.data.Clone(), true
 	}
 }
-
-// func (sc *StateCache) getValue(key, blockHash string) (valueNode, bool) {
-// 	// sc.mu.RLock()
-// 	// defer sc.mu.RUnlock()
-
-// 	blockValues, ok := sc.cache.Get(key)
-// 	if !ok {
-// 		return valueNode{}, false
-// 	}
-
-// 	vv, ok := blockValues.(*lru.Cache).Get(blockHash)
-// 	v := vv.(valueNode)
-// 	if ok && !v.deleted {
-// 		v.data = v.data.Clone()
-// 		return v, true
-// 	}
-// 	return valueNode{}, false
-// }
-
-// shift copy the value from previous block to current
-// func (sc *StateCache) shift(prevHash, blockHash string) {
-// 	if prevHash == "" || blockHash == "" {
-// 		return
-// 	}
-// 	tm := time.Now()
-
-// 	keys := sc.cache.Keys()
-// 	for _, key := range keys {
-// 		blockValues, ok := sc.cache.Get(key)
-// 		if ok {
-// 			bvs := blockValues.(*lru.Cache)
-// 			vv, ok := bvs.Get(prevHash)
-// 			if ok {
-// 				// shift the value from previous block when it does not exist in present block
-// 				if _, exist := bvs.Get(blockHash); !exist {
-// 					v := vv.(valueNode)
-// 					v.data = v.data.Clone()
-// 					bvs.Add(blockHash, v)
-// 					sc.cache.Add(key, bvs)
-// 				}
-// 			}
-// 		}
-// 	}
-
-// for key, blockValues := range sc.cache {
-// 	v, ok := blockValues[prevHash]
-// 	if ok {
-// 		if _, exists := blockValues[blockHash]; !exists {
-// 			if sc.cache[key] == nil {
-// 				sc.cache[key] = make(map[string]valueNode)
-// 			}
-// 			v.data = v.data.Clone()
-// 			sc.cache[key][blockHash] = v
-// 		}
-// 	}
-// }
-
-// logging.Logger.Debug("state cache - shift", zap.Any("duration", time.Since(tm)))
-// }
 
 // Remove removes the values map with the given key
 func (sc *StateCache) Remove(key string) {
@@ -222,76 +142,3 @@ func (sc *StateCache) Remove(key string) {
 	sc.cache.Remove(key)
 	// delete(sc.cache, key)
 }
-
-// PruneRoundBelow removes all values that are below the given round
-// func (sc *StateCache) PruneRoundBelow(round int64) {
-// 	sc.mu.Lock()
-// 	defer sc.mu.Unlock()
-
-// 	var count int
-// 	for key, blockValues := range sc.cache {
-// 		for blockHash, value := range blockValues {
-// 			if value.round < round {
-// 				count++
-// 				delete(blockValues, blockHash)
-// 			}
-// 		}
-
-// 		// Delete the map if it becomes empty
-// 		if len(blockValues) == 0 {
-// 			delete(sc.cache, key)
-// 		}
-// 	}
-
-// 	logging.Logger.Debug("state cache - prune_round_below", zap.Int64("round", round), zap.Int("count", count))
-// }
-
-// PrettyPrint prints the state cache in a pretty format
-// func (sc *StateCache) PrettyPrint() {
-// 	sc.mu.RLock()
-// 	defer sc.mu.RUnlock()
-
-// 	// Sort keys in alphabetical order
-// 	var keys []string
-// 	for key := range sc.cache {
-// 		keys = append(keys, key)
-// 	}
-// 	sort.Strings(keys)
-
-// 	// Print values for each key
-// 	for _, key := range keys {
-// 		fmt.Printf("Key: %s\n", key)
-
-// 		blockValues := sc.cache[key]
-
-// 		// Sort block hashes by round number in descending order
-// 		var rounds []int64
-// 		for _, value := range blockValues {
-// 			rounds = append(rounds, value.round)
-// 		}
-// 		sort.Slice(rounds, func(i, j int) bool {
-// 			return rounds[i] > rounds[j]
-// 		})
-
-// 		// Print values for each round
-// 		for _, round := range rounds {
-// 			fmt.Printf("  Round: %d\n", round)
-
-// 			// Sort block hashes for the same round
-// 			var hashes []string
-// 			for hash, value := range blockValues {
-// 				if value.round == round {
-// 					hashes = append(hashes, hash)
-// 				}
-// 			}
-// 			sort.Strings(hashes)
-
-// 			// Print values for each hash
-// 			for _, hash := range hashes {
-// 				value := blockValues[hash]
-// 				fmt.Printf("    Hash: %s\n", hash)
-// 				fmt.Printf("      Deleted: %v\n", value.deleted)
-// 			}
-// 		}
-// 	}
-// }

--- a/core/statecache/statecache.go
+++ b/core/statecache/statecache.go
@@ -61,7 +61,7 @@ type StateCache struct {
 }
 
 func NewStateCache() *StateCache {
-	cache, err := lru.New(1024 * 1024)
+	cache, err := lru.New(100 * 1024)
 	if err != nil {
 		panic(err)
 	}

--- a/core/statecache/statecache.go
+++ b/core/statecache/statecache.go
@@ -82,10 +82,13 @@ func NewStateCache() *StateCache {
 
 func (sc *StateCache) commitRound(round int64, prevHash, blockHash string) {
 	sc.mu.Lock()
-	if sc.lastCommitRound+1 != round {
+	// update the lastCommitRound and lastBreakRound only when round is greater than lastCommitRound
+	// this is because the commitRound could happen for old rounds
+	if round > sc.lastCommitRound && sc.lastCommitRound+1 != round {
 		sc.lastBreakRound = round // any valueNode with Round < lastBreakRound is stale
+		sc.lastCommitRound = round
 	}
-	sc.lastCommitRound = round
+
 	sc.mu.Unlock()
 	sc.hashCache.Add(blockHash, prevHash)
 }

--- a/core/statecache/statecache.go
+++ b/core/statecache/statecache.go
@@ -1,11 +1,10 @@
 package statecache
 
 import (
-	"fmt"
-	"sort"
-	"sync"
+	"time"
 
 	"github.com/0chain/common/core/logging"
+	lru "github.com/hashicorp/golang-lru"
 	"go.uber.org/zap"
 )
 
@@ -56,32 +55,41 @@ type valueNode struct {
 }
 
 type StateCache struct {
-	mu    sync.RWMutex
-	cache map[string]map[string]valueNode
+	// mu sync.RWMutex
+	// cache map[string]map[string]valueNode
+	cache *lru.Cache
 }
 
 func NewStateCache() *StateCache {
+	cache, err := lru.New(1024 * 1024)
+	if err != nil {
+		panic(err)
+	}
+
 	return &StateCache{
-		cache: make(map[string]map[string]valueNode),
+		// cache: make(map[string]map[string]valueNode),
+		cache: cache,
 	}
 }
 
 // Get returns the value with the given key and block hash
 func (sc *StateCache) Get(key, blockHash string) (Value, bool) {
-	sc.mu.RLock()
-	defer sc.mu.RUnlock()
+	// sc.mu.RLock()
+	// defer sc.mu.RUnlock()
 
-	blockValues, ok := sc.cache[key]
+	blockValues, ok := sc.cache.Get(key)
 	if !ok {
 		// logging.Logger.Debug("state cache get - not found", zap.String("key", key))
 		return nil, false
 	}
 
-	v, ok := blockValues[blockHash]
+	vv, ok := blockValues.(*lru.Cache).Get(blockHash)
 	if !ok {
 		// logging.Logger.Debug("state cache get - key found, value not found", zap.String("key", key))
 		return nil, false
 	}
+
+	v := vv.(valueNode)
 
 	if !v.deleted {
 		// logging.Logger.Debug("state cache get", zap.String("key", key))
@@ -93,15 +101,16 @@ func (sc *StateCache) Get(key, blockHash string) (Value, bool) {
 }
 
 func (sc *StateCache) getValue(key, blockHash string) (valueNode, bool) {
-	sc.mu.RLock()
-	defer sc.mu.RUnlock()
+	// sc.mu.RLock()
+	// defer sc.mu.RUnlock()
 
-	blockValues, ok := sc.cache[key]
+	blockValues, ok := sc.cache.Get(key)
 	if !ok {
 		return valueNode{}, false
 	}
 
-	v, ok := blockValues[blockHash]
+	vv, ok := blockValues.(*lru.Cache).Get(blockHash)
+	v := vv.(valueNode)
 	if ok && !v.deleted {
 		v.data = v.data.Clone()
 		return v, true
@@ -114,98 +123,120 @@ func (sc *StateCache) shift(prevHash, blockHash string) {
 	if prevHash == "" || blockHash == "" {
 		return
 	}
+	tm := time.Now()
 
-	for key, blockValues := range sc.cache {
-		v, ok := blockValues[prevHash]
+	keys := sc.cache.Keys()
+	for _, key := range keys {
+		blockValues, ok := sc.cache.Get(key)
 		if ok {
-			if _, exists := blockValues[blockHash]; !exists {
-				if sc.cache[key] == nil {
-					sc.cache[key] = make(map[string]valueNode)
+			bvs := blockValues.(*lru.Cache)
+			vv, ok := bvs.Get(prevHash)
+			if ok {
+				// shift the value from previous block when it does not exist in present block
+				if _, exist := bvs.Get(blockHash); !exist {
+					v := vv.(valueNode)
+					v.data = v.data.Clone()
+					bvs.Add(blockHash, v)
+					sc.cache.Add(key, bvs)
 				}
-				v.data = v.data.Clone()
-				sc.cache[key][blockHash] = v
 			}
 		}
 	}
+
+	// for key, blockValues := range sc.cache {
+	// 	v, ok := blockValues[prevHash]
+	// 	if ok {
+	// 		if _, exists := blockValues[blockHash]; !exists {
+	// 			if sc.cache[key] == nil {
+	// 				sc.cache[key] = make(map[string]valueNode)
+	// 			}
+	// 			v.data = v.data.Clone()
+	// 			sc.cache[key][blockHash] = v
+	// 		}
+	// 	}
+	// }
+
+	logging.Logger.Debug("state cache - shift", zap.Any("duration", time.Since(tm)))
 }
 
 // Remove removes the values map with the given key
 func (sc *StateCache) Remove(key string) {
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
+	// sc.mu.Lock()
+	// defer sc.mu.Unlock()
 
-	delete(sc.cache, key)
+	sc.cache.Remove(key)
+	// delete(sc.cache, key)
 }
 
 // PruneRoundBelow removes all values that are below the given round
-func (sc *StateCache) PruneRoundBelow(round int64) {
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
+// func (sc *StateCache) PruneRoundBelow(round int64) {
+// 	sc.mu.Lock()
+// 	defer sc.mu.Unlock()
 
-	var count int
-	for key, blockValues := range sc.cache {
-		for blockHash, value := range blockValues {
-			if value.round < round {
-				count++
-				delete(blockValues, blockHash)
-			}
-		}
+// 	var count int
+// 	for key, blockValues := range sc.cache {
+// 		for blockHash, value := range blockValues {
+// 			if value.round < round {
+// 				count++
+// 				delete(blockValues, blockHash)
+// 			}
+// 		}
 
-		// Delete the map if it becomes empty
-		if len(blockValues) == 0 {
-			delete(sc.cache, key)
-		}
-	}
+// 		// Delete the map if it becomes empty
+// 		if len(blockValues) == 0 {
+// 			delete(sc.cache, key)
+// 		}
+// 	}
 
-	logging.Logger.Debug("state cache - prune_round_below", zap.Int64("round", round), zap.Int("count", count))
-}
+// 	logging.Logger.Debug("state cache - prune_round_below", zap.Int64("round", round), zap.Int("count", count))
+// }
 
 // PrettyPrint prints the state cache in a pretty format
-func (sc *StateCache) PrettyPrint() {
-	sc.mu.RLock()
-	defer sc.mu.RUnlock()
+// func (sc *StateCache) PrettyPrint() {
+// 	sc.mu.RLock()
+// 	defer sc.mu.RUnlock()
 
-	// Sort keys in alphabetical order
-	var keys []string
-	for key := range sc.cache {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
+// 	// Sort keys in alphabetical order
+// 	var keys []string
+// 	for key := range sc.cache {
+// 		keys = append(keys, key)
+// 	}
+// 	sort.Strings(keys)
 
-	// Print values for each key
-	for _, key := range keys {
-		fmt.Printf("Key: %s\n", key)
+// 	// Print values for each key
+// 	for _, key := range keys {
+// 		fmt.Printf("Key: %s\n", key)
 
-		blockValues := sc.cache[key]
+// 		blockValues := sc.cache[key]
 
-		// Sort block hashes by round number in descending order
-		var rounds []int64
-		for _, value := range blockValues {
-			rounds = append(rounds, value.round)
-		}
-		sort.Slice(rounds, func(i, j int) bool {
-			return rounds[i] > rounds[j]
-		})
+// 		// Sort block hashes by round number in descending order
+// 		var rounds []int64
+// 		for _, value := range blockValues {
+// 			rounds = append(rounds, value.round)
+// 		}
+// 		sort.Slice(rounds, func(i, j int) bool {
+// 			return rounds[i] > rounds[j]
+// 		})
 
-		// Print values for each round
-		for _, round := range rounds {
-			fmt.Printf("  Round: %d\n", round)
+// 		// Print values for each round
+// 		for _, round := range rounds {
+// 			fmt.Printf("  Round: %d\n", round)
 
-			// Sort block hashes for the same round
-			var hashes []string
-			for hash, value := range blockValues {
-				if value.round == round {
-					hashes = append(hashes, hash)
-				}
-			}
-			sort.Strings(hashes)
+// 			// Sort block hashes for the same round
+// 			var hashes []string
+// 			for hash, value := range blockValues {
+// 				if value.round == round {
+// 					hashes = append(hashes, hash)
+// 				}
+// 			}
+// 			sort.Strings(hashes)
 
-			// Print values for each hash
-			for _, hash := range hashes {
-				value := blockValues[hash]
-				fmt.Printf("    Hash: %s\n", hash)
-				fmt.Printf("      Deleted: %v\n", value.deleted)
-			}
-		}
-	}
-}
+// 			// Print values for each hash
+// 			for _, hash := range hashes {
+// 				value := blockValues[hash]
+// 				fmt.Printf("    Hash: %s\n", hash)
+// 				fmt.Printf("      Deleted: %v\n", value.deleted)
+// 			}
+// 		}
+// 	}
+// }

--- a/core/statecache/statecache.go
+++ b/core/statecache/statecache.go
@@ -93,7 +93,7 @@ func (sc *StateCache) commit(bc *BlockCache) {
 	defer sc.lock.Unlock()
 
 	_, ok := sc.hashCache.Get(bc.blockHash)
-	if !ok {
+	if ok {
 		// block already committed
 		return
 	}

--- a/core/statecache/statecache.go
+++ b/core/statecache/statecache.go
@@ -1,0 +1,211 @@
+package statecache
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/0chain/common/core/logging"
+	"go.uber.org/zap"
+)
+
+// NewBlockTxnCaches creates a new block cache and a transaction cache for the given block
+func NewBlockTxnCaches(sc *StateCache, b Block) (*BlockCache, *TransactionCache) {
+	bc := NewBlockCache(sc, b)
+	tc := NewTransactionCache(bc)
+	return bc, tc
+}
+
+// Value is an interface that all values in the state cache must implement
+type Value interface {
+	Clone() Value
+	CopyFrom(v interface{}) bool
+}
+
+type String string
+
+func (se String) Clone() Value {
+	return se
+}
+
+func (set String) CopyFrom(v interface{}) bool {
+	return false
+}
+
+// Cacheable checks if the given value is able to be cached
+func Cacheable(v interface{}) (Value, bool) {
+	cv, ok := v.(Value)
+	return cv, ok
+}
+
+type Copyer interface {
+	// CopyFrom copies the value from the given value, returns false if not able to copy
+	CopyFrom(v interface{}) bool
+}
+
+// Copyable checks if the given value is able to be copied
+func Copyable(v interface{}) (Copyer, bool) {
+	cv, ok := v.(Copyer)
+	return cv, ok
+}
+
+type valueNode struct {
+	data    Value
+	deleted bool  // indicates the value was removed
+	round   int64 // round number when this value is updated
+}
+
+type StateCache struct {
+	mu    sync.RWMutex
+	cache map[string]map[string]valueNode
+}
+
+func NewStateCache() *StateCache {
+	return &StateCache{
+		cache: make(map[string]map[string]valueNode),
+	}
+}
+
+// Get returns the value with the given key and block hash
+func (sc *StateCache) Get(key, blockHash string) (Value, bool) {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+
+	blockValues, ok := sc.cache[key]
+	if !ok {
+		logging.Logger.Debug("state cache get - not found", zap.String("key", key))
+		return nil, false
+	}
+
+	v, ok := blockValues[blockHash]
+	if !ok {
+		logging.Logger.Debug("state cache get - key found, value not found", zap.String("key", key))
+		return nil, false
+	}
+
+	if !v.deleted {
+		logging.Logger.Debug("state cache get", zap.String("key", key))
+		return v.data.Clone(), true
+	}
+
+	logging.Logger.Debug("state cache get - deleted", zap.String("key", key))
+	return nil, false
+}
+
+func (sc *StateCache) getValue(key, blockHash string) (valueNode, bool) {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+
+	blockValues, ok := sc.cache[key]
+	if !ok {
+		return valueNode{}, false
+	}
+
+	v, ok := blockValues[blockHash]
+	if ok && !v.deleted {
+		v.data = v.data.Clone()
+		return v, true
+	}
+	return valueNode{}, false
+}
+
+// shift copy the value from previous block to current
+func (sc *StateCache) shift(prevHash, blockHash string) {
+	if prevHash == "" || blockHash == "" {
+		return
+	}
+
+	for key, blockValues := range sc.cache {
+		v, ok := blockValues[prevHash]
+		if ok {
+			if _, exists := blockValues[blockHash]; !exists {
+				if sc.cache[key] == nil {
+					sc.cache[key] = make(map[string]valueNode)
+				}
+				v.data = v.data.Clone()
+				sc.cache[key][blockHash] = v
+			}
+		}
+	}
+}
+
+// Remove removes the values map with the given key
+func (sc *StateCache) Remove(key string) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	delete(sc.cache, key)
+}
+
+// PruneRoundBelow removes all values that are below the given round
+func (sc *StateCache) PruneRoundBelow(round int64) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	var count int
+	for key, blockValues := range sc.cache {
+		for blockHash, value := range blockValues {
+			if value.round < round {
+				count++
+				delete(blockValues, blockHash)
+			}
+		}
+
+		// Delete the map if it becomes empty
+		if len(blockValues) == 0 {
+			delete(sc.cache, key)
+		}
+	}
+
+	logging.Logger.Debug("state cache - prune_round_below", zap.Int64("round", round), zap.Int("count", count))
+}
+
+// PrettyPrint prints the state cache in a pretty format
+func (sc *StateCache) PrettyPrint() {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+
+	// Sort keys in alphabetical order
+	var keys []string
+	for key := range sc.cache {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	// Print values for each key
+	for _, key := range keys {
+		fmt.Printf("Key: %s\n", key)
+
+		blockValues := sc.cache[key]
+
+		// Sort block hashes by round number in descending order
+		var rounds []int64
+		for _, value := range blockValues {
+			rounds = append(rounds, value.round)
+		}
+		sort.Slice(rounds, func(i, j int) bool {
+			return rounds[i] > rounds[j]
+		})
+
+		// Print values for each round
+		for _, round := range rounds {
+			fmt.Printf("  Round: %d\n", round)
+
+			// Sort block hashes for the same round
+			var hashes []string
+			for hash, value := range blockValues {
+				if value.round == round {
+					hashes = append(hashes, hash)
+				}
+			}
+			sort.Strings(hashes)
+
+			// Print values for each hash
+			for _, hash := range hashes {
+				value := blockValues[hash]
+				fmt.Printf("    Hash: %s\n", hash)
+				fmt.Printf("      Deleted: %v\n", value.deleted)
+			}
+		}
+	}
+}

--- a/core/statecache/statecache.go
+++ b/core/statecache/statecache.go
@@ -161,7 +161,7 @@ func (sc *StateCache) Get(key, blockHash string) (Value, bool) {
 		return nil, false
 	}
 
-	// oldBlockHash := blockHash
+	oldBlockHash := blockHash
 
 	var count int
 	for {
@@ -188,19 +188,19 @@ func (sc *StateCache) Get(key, blockHash string) (Value, bool) {
 
 		v := vv.(valueNode)
 
-		// save into current block cache only when it's 20 rounds behind
+		// // save into current block cache when it's 20 rounds behind
 		// if count >= 20 {
-		// 	bvsi, err := lru.New(200)
-		// 	if err != nil {
-		// 		panic(err)
-		// 	}
+		bvsi, err := lru.New(200)
+		if err != nil {
+			panic(err)
+		}
 
-		// 	bvsi.Add(oldBlockHash, v)
+		bvsi.Add(oldBlockHash, v)
 
-		// 	sc.cache.Add(key, bvsi)
-		// 	logging.Logger.Debug("state cache - migrate from previous block",
-		// 		zap.String("key", key),
-		// 		zap.Int("depth", count))
+		sc.cache.Add(key, bvsi)
+		// logging.Logger.Debug("state cache - migrate from previous block",
+		// 	zap.String("key", key),
+		// 	zap.Int("depth", count))
 		// }
 
 		if v.deleted {

--- a/core/statecache/statecache_test.go
+++ b/core/statecache/statecache_test.go
@@ -367,68 +367,6 @@ func TestTransactionCacheRemove(t *testing.T) {
 	require.False(t, ok)
 }
 
-// func TestStateCache_PruneRoundBelow(t *testing.T) {
-// 	sc := NewStateCache()
-
-// 	// Add some values to the cache
-// 	value1 := valueNode{data: String("data1"), round: 1}
-// 	value2 := valueNode{data: String("data2"), round: 2}
-// 	value3 := valueNode{data: String("data3"), round: 3}
-// 	value4 := valueNode{data: String("data4"), round: 4}
-
-// 	bvs, _ := lru.New(10)
-// 	bvs.Add("hash1", value1)
-// 	bvs.Add("hash2", value2)
-// 	bvs.Add("hash3", value3)
-// 	bvs.Add("hash4", value4)
-
-// 	sc.cache.Add("key1", bvs)
-
-// 	// sc.cache["key1"] = map[string]valueNode{
-// 	// 	"hash1": value1,
-// 	// 	"hash2": value2,
-// 	// 	"hash3": value3,
-// 	// 	"hash4": value4,
-// 	// }
-
-// 	// sc.PrettyPrint()
-
-// 	// Prune values with round below 3
-// 	sc.PruneRoundBelow(3)
-
-// 	// Verify that values with round below 3 are pruned
-// 	_, ok := sc.cache["key1"]["hash1"]
-// 	require.False(t, ok)
-
-// 	_, ok = sc.cache["key1"]["hash2"]
-// 	require.False(t, ok)
-
-// 	_, ok = sc.cache["key1"]["hash3"]
-// 	require.True(t, ok)
-
-// 	_, ok = sc.cache["key1"]["hash4"]
-// 	require.True(t, ok)
-
-// 	sc.PrettyPrint()
-
-// 	// Prune values with round below 5
-// 	sc.PruneRoundBelow(5)
-
-// 	// Verify that all values are pruned
-// 	_, ok = sc.cache["key1"]["hash1"]
-// 	require.False(t, ok)
-
-// 	_, ok = sc.cache["key1"]["hash2"]
-// 	require.False(t, ok)
-
-// 	_, ok = sc.cache["key1"]["hash3"]
-// 	require.False(t, ok)
-
-// 	_, ok = sc.cache["key1"]["hash4"]
-// 	require.False(t, ok)
-// 	sc.PrettyPrint()
-// }
-
 type Foo struct {
 	V string
 }

--- a/core/statecache/statecache_test.go
+++ b/core/statecache/statecache_test.go
@@ -336,59 +336,68 @@ func TestTransactionCache(t *testing.T) {
 		require.EqualValues(t, value1, v)
 	}
 }
-func TestStateCache_PruneRoundBelow(t *testing.T) {
-	sc := NewStateCache()
 
-	// Add some values to the cache
-	value1 := valueNode{data: String("data1"), round: 1}
-	value2 := valueNode{data: String("data2"), round: 2}
-	value3 := valueNode{data: String("data3"), round: 3}
-	value4 := valueNode{data: String("data4"), round: 4}
+// func TestStateCache_PruneRoundBelow(t *testing.T) {
+// 	sc := NewStateCache()
 
-	sc.cache["key1"] = map[string]valueNode{
-		"hash1": value1,
-		"hash2": value2,
-		"hash3": value3,
-		"hash4": value4,
-	}
+// 	// Add some values to the cache
+// 	value1 := valueNode{data: String("data1"), round: 1}
+// 	value2 := valueNode{data: String("data2"), round: 2}
+// 	value3 := valueNode{data: String("data3"), round: 3}
+// 	value4 := valueNode{data: String("data4"), round: 4}
 
-	sc.PrettyPrint()
+// 	bvs, _ := lru.New(10)
+// 	bvs.Add("hash1", value1)
+// 	bvs.Add("hash2", value2)
+// 	bvs.Add("hash3", value3)
+// 	bvs.Add("hash4", value4)
 
-	// Prune values with round below 3
-	sc.PruneRoundBelow(3)
+// 	sc.cache.Add("key1", bvs)
 
-	// Verify that values with round below 3 are pruned
-	_, ok := sc.cache["key1"]["hash1"]
-	require.False(t, ok)
+// 	// sc.cache["key1"] = map[string]valueNode{
+// 	// 	"hash1": value1,
+// 	// 	"hash2": value2,
+// 	// 	"hash3": value3,
+// 	// 	"hash4": value4,
+// 	// }
 
-	_, ok = sc.cache["key1"]["hash2"]
-	require.False(t, ok)
+// 	// sc.PrettyPrint()
 
-	_, ok = sc.cache["key1"]["hash3"]
-	require.True(t, ok)
+// 	// Prune values with round below 3
+// 	sc.PruneRoundBelow(3)
 
-	_, ok = sc.cache["key1"]["hash4"]
-	require.True(t, ok)
+// 	// Verify that values with round below 3 are pruned
+// 	_, ok := sc.cache["key1"]["hash1"]
+// 	require.False(t, ok)
 
-	sc.PrettyPrint()
+// 	_, ok = sc.cache["key1"]["hash2"]
+// 	require.False(t, ok)
 
-	// Prune values with round below 5
-	sc.PruneRoundBelow(5)
+// 	_, ok = sc.cache["key1"]["hash3"]
+// 	require.True(t, ok)
 
-	// Verify that all values are pruned
-	_, ok = sc.cache["key1"]["hash1"]
-	require.False(t, ok)
+// 	_, ok = sc.cache["key1"]["hash4"]
+// 	require.True(t, ok)
 
-	_, ok = sc.cache["key1"]["hash2"]
-	require.False(t, ok)
+// 	sc.PrettyPrint()
 
-	_, ok = sc.cache["key1"]["hash3"]
-	require.False(t, ok)
+// 	// Prune values with round below 5
+// 	sc.PruneRoundBelow(5)
 
-	_, ok = sc.cache["key1"]["hash4"]
-	require.False(t, ok)
-	sc.PrettyPrint()
-}
+// 	// Verify that all values are pruned
+// 	_, ok = sc.cache["key1"]["hash1"]
+// 	require.False(t, ok)
+
+// 	_, ok = sc.cache["key1"]["hash2"]
+// 	require.False(t, ok)
+
+// 	_, ok = sc.cache["key1"]["hash3"]
+// 	require.False(t, ok)
+
+// 	_, ok = sc.cache["key1"]["hash4"]
+// 	require.False(t, ok)
+// 	sc.PrettyPrint()
+// }
 
 type Foo struct {
 	V string

--- a/core/statecache/statecache_test.go
+++ b/core/statecache/statecache_test.go
@@ -263,14 +263,17 @@ func TestAddRemoveAdd(t *testing.T) {
 	_, ok = sc.Get("key1", "hash2")
 	require.False(t, ok)
 
+	ct3 := NewBlockCache(sc, Block{PrevHash: "hash2", Hash: "hash3"})
 	// Add the value again to the CacheTx
-	ct2.Set("key1", String("value1"))
+	ct3.Set("key1", String("value1"))
+
+	// ct2.Set("key1", String("value1"))
 
 	// Commit the CacheTx
-	ct2.Commit()
+	ct3.Commit()
 
 	// Verify that the value is added back to the StateCache
-	v2, ok := sc.Get("key1", "hash2")
+	v2, ok := sc.Get("key1", "hash3")
 	require.True(t, ok)
 	require.EqualValues(t, "value1", v2)
 }

--- a/core/statecache/statecache_test.go
+++ b/core/statecache/statecache_test.go
@@ -1,0 +1,472 @@
+package statecache
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/0chain/common/core/logging"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	logging.InitLogging("development", "")
+}
+
+func TestStateCacheSetGet(t *testing.T) {
+	sc := NewStateCache()
+
+	// Test Get method when cache is empty
+	_, ok := sc.Get("key1", "hash1")
+	if ok {
+		t.Error("Expected false, got ", ok)
+	}
+
+	bc := NewBlockCache(sc, Block{Hash: "hash1"})
+	bc.Set("key1", String("data1"))
+	bc.Commit()
+
+	// Test Get method when cache has a value
+	v, ok := sc.Get("key1", "hash1")
+	if !ok {
+		t.Error("Expected true, got ", ok)
+	}
+	if v.(String) != "data1" {
+		t.Error("Expected data1, got ", v)
+	}
+}
+
+func TestBlockCache(t *testing.T) {
+	sc := NewStateCache()
+	ct := NewBlockCache(sc, Block{Hash: "hash1"})
+
+	// Test Get method when cache is empty
+	_, ok := ct.Get("key1")
+	if ok {
+		t.Error("Expected false, got ", ok)
+	}
+
+	// Test Set method
+	ct.Set("key1", String("value1"))
+	value, ok := ct.Get("key1")
+	require.True(t, ok)
+	require.EqualValues(t, "value1", value)
+
+	// Test Commit method
+	ct.Set("key2", String("value2"))
+
+	ct.Commit()
+	value, ok = sc.Get("key2", "hash1")
+	require.True(t, ok)
+	require.EqualValues(t, "value2", value)
+
+	// Add a new value to the cache for key1 in hash2 block
+	value2 := String("data2")
+	ct2 := NewBlockCache(sc, Block{PrevHash: "hash1", Hash: "hash2"})
+	ct2.Set("key1", value2)
+	ct2.Commit()
+
+	// Get cache in current block
+	v2, ok := sc.Get("key1", "hash2")
+	require.True(t, ok)
+	require.EqualValues(t, "data2", v2)
+
+	// Get cache in prior block
+	v1, ok := sc.Get("key1", "hash1")
+	require.True(t, ok)
+	require.EqualValues(t, "value1", v1)
+}
+
+func TestCacheTx_NotCommitted(t *testing.T) {
+	sc := NewStateCache()
+	ct := NewBlockCache(sc, Block{Round: 1, Hash: "hash1"})
+
+	// Test Get method when cache is empty
+	_, ok := ct.Get("key1")
+	require.False(t, ok)
+
+	// Test Set method
+	ct.Set("key1", String("value1"))
+	value, ok := ct.Get("key1")
+	require.True(t, ok)
+	require.EqualValues(t, "value1", value)
+
+	// Test Get method in state cache before committing
+	_, ok = sc.Get("key1", "hash1")
+	require.False(t, ok)
+
+	ct.Commit()
+	_, ok = sc.Get("key1", "hash1")
+	require.True(t, ok)
+
+	ct = NewBlockCache(sc, Block{Round: 2, Hash: "hash2", PrevHash: "hash1"})
+	_, ok = ct.Get("key1")
+	require.True(t, ok)
+
+	// Test Remove method
+	ct.remove("key1")
+	_, ok = ct.Get("key1")
+	require.False(t, ok)
+	if ok {
+		t.Error("Expected false, got ", ok)
+	}
+
+	ct.Commit()
+
+	_, ok = sc.Get("key1", "hash2")
+	require.False(t, ok)
+
+	// should be exist in hash1
+	v, ok := sc.Get("key1", "hash1")
+	require.True(t, ok)
+	require.EqualValues(t, "value1", v)
+}
+
+func TestCacheTx_SkipBlock(t *testing.T) {
+	sc := NewStateCache()
+	ct := NewBlockCache(sc, Block{Hash: "hash1"})
+
+	// Add values to the cache in block "hash1"
+	ct.Set("key1", String("value1"))
+
+	// Commit the changes to the main cache
+	ct.Commit()
+
+	// Skip one block
+	ct = NewBlockCache(sc, Block{PrevHash: "hash2", Hash: "hash3"})
+
+	_, ok := ct.Get("key1")
+	require.False(t, ok)
+
+	// Add a new value to the cache in block "hash3"
+	ct.Set("key1", String("value3"))
+
+	_, ok = ct.Get("key1")
+	require.True(t, ok)
+
+	ct.Commit()
+	v, ok := sc.Get("key1", "hash3")
+	require.True(t, ok)
+	require.EqualValues(t, "value3", v)
+}
+
+func TestCacheTx_Shift(t *testing.T) {
+	sc := NewStateCache()
+	ct := NewBlockCache(sc, Block{Hash: "hash1"})
+
+	// Add values to the cache in block "hash1"
+	ct.Set("key1", String("value1_h1"))
+	ct.Set("key2", String("value2_h1"))
+
+	// Commit the changes to the main cache
+	ct.Commit()
+
+	// New block that update key1 only
+	ct = NewBlockCache(sc, Block{PrevHash: "hash1", Hash: "hash2"})
+	ct.Set("key1", String("value1_h2"))
+	ct.Commit()
+
+	// Commit should trigger shift of key2 from hash1 to hash2
+	v, ok := sc.Get("key2", "hash2")
+	require.True(t, ok)
+	require.EqualValues(t, "value2_h1", v)
+
+	// New block to update both key1 and key2
+	ct = NewBlockCache(sc, Block{PrevHash: "hash2", Hash: "hash3"})
+	ct.Set("key1", String("value1_h3"))
+	ct.Set("key2", String("value2_h3"))
+
+	v1, ok := ct.Get("key1")
+	require.True(t, ok)
+	require.EqualValues(t, "value1_h3", v1)
+
+	v2, ok := ct.Get("key2")
+	require.True(t, ok)
+	require.EqualValues(t, "value2_h3", v2)
+
+	ct.Commit()
+
+	v1, ok = sc.Get("key1", "hash3")
+	require.True(t, ok)
+	require.EqualValues(t, "value1_h3", v1)
+
+	v2, ok = sc.Get("key2", "hash3")
+	require.True(t, ok)
+	require.EqualValues(t, "value2_h3", v2)
+}
+
+func TestConcurrentExecutionAndCommit(t *testing.T) {
+	sc := NewStateCache()
+
+	// Create two concurrent CacheTx instances for the same block
+	ct1 := NewBlockCache(sc, Block{Hash: "hash1"})
+	ct2 := NewBlockCache(sc, Block{Hash: "hash1"})
+
+	// Set values in both CacheTx instances
+	ct1.Set("key1", String("value1_h1"))
+	ct2.Set("key1", String("value1_h1"))
+
+	// Concurrently commit both CacheTx instances
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		ct1.Commit()
+	}()
+
+	go func() {
+		defer wg.Done()
+		ct2.Commit()
+	}()
+
+	wg.Wait()
+
+	// Verify that the cache is the same after concurrent execution and commit
+	v1, ok := sc.Get("key1", "hash1")
+	require.True(t, ok)
+	require.EqualValues(t, "value1_h1", v1)
+}
+
+func TestAddRemoveAdd(t *testing.T) {
+	sc := NewStateCache()
+
+	// Create a CacheTx instance
+	ct := NewBlockCache(sc, Block{Hash: "hash1"})
+
+	// Add a value to the CacheTx
+	ct.Set("key1", String(string([]byte("value1"))))
+
+	// Commit the CacheTx
+	ct.Commit()
+
+	// Verify that the value is added to the StateCache
+	v1, ok := sc.Get("key1", "hash1")
+	require.True(t, ok)
+	require.EqualValues(t, "value1", v1)
+
+	// Create another CacheTx instance
+	ct2 := NewBlockCache(sc, Block{PrevHash: "hash1", Hash: "hash2"})
+
+	// Remove the value from the CacheTx
+	ct2.remove("key1")
+
+	// Commit the CacheTx
+	ct2.Commit()
+
+	// Verify that the value is removed from the StateCache
+	_, ok = sc.Get("key1", "hash2")
+	require.False(t, ok)
+
+	// Add the value again to the CacheTx
+	ct2.Set("key1", String("value1"))
+
+	// Commit the CacheTx
+	ct2.Commit()
+
+	// Verify that the value is added back to the StateCache
+	v2, ok := sc.Get("key1", "hash2")
+	require.True(t, ok)
+	require.EqualValues(t, "value1", v2)
+}
+
+func TestTransactionCache(t *testing.T) {
+	sc := NewStateCache()
+
+	for i := 0; i < 10; i++ {
+		hash := fmt.Sprintf("hash%d", i)
+		var preHash string
+		if i > 0 {
+			preHash = fmt.Sprintf("hash%d", i-1)
+		}
+
+		bc := NewBlockCache(sc, Block{PrevHash: preHash, Hash: hash})
+		tc := NewTransactionCache(bc)
+
+		// Test Get method when cache is empty
+		_, ok := tc.Get("key1")
+		if ok && i == 0 {
+			t.Error("Expected false, got ", ok)
+		}
+
+		// Test Set method
+		value1 := fmt.Sprintf("value1_%s", hash)
+		tc.Set("key1", String(fmt.Sprintf("value1_%s", hash)))
+		value, ok := tc.Get("key1")
+		require.True(t, ok)
+		require.EqualValues(t, value1, value)
+
+		// Test Commit method
+		value2 := fmt.Sprintf("value2_%s", hash)
+		tc.Set("key2", String(value2))
+		tc.Commit()
+
+		v1, ok := bc.Get("key1")
+		require.True(t, ok)
+		require.EqualValues(t, value1, v1)
+
+		v2, ok := bc.Get("key2")
+		require.True(t, ok)
+		require.EqualValues(t, value2, v2)
+
+		// sc should not have the values yet before commit
+		_, ok = sc.Get("key1", hash)
+		require.False(t, ok)
+
+		_, ok = sc.Get("key2", hash)
+		require.False(t, ok)
+
+		// sc should see the values after commit
+		bc.Commit()
+		vv1, ok := sc.Get("key1", hash)
+		require.True(t, ok)
+		require.EqualValues(t, value1, vv1)
+
+		vv2, ok := sc.Get("key2", hash)
+		require.True(t, ok)
+		require.EqualValues(t, value2, vv2)
+	}
+
+	for i := 0; i < 10; i++ {
+		hash := fmt.Sprintf("hash%d", i)
+		value1 := fmt.Sprintf("value1_%s", hash)
+		v, ok := sc.Get("key1", hash)
+		require.True(t, ok)
+		require.EqualValues(t, value1, v)
+	}
+}
+func TestStateCache_PruneRoundBelow(t *testing.T) {
+	sc := NewStateCache()
+
+	// Add some values to the cache
+	value1 := valueNode{data: String("data1"), round: 1}
+	value2 := valueNode{data: String("data2"), round: 2}
+	value3 := valueNode{data: String("data3"), round: 3}
+	value4 := valueNode{data: String("data4"), round: 4}
+
+	sc.cache["key1"] = map[string]valueNode{
+		"hash1": value1,
+		"hash2": value2,
+		"hash3": value3,
+		"hash4": value4,
+	}
+
+	sc.PrettyPrint()
+
+	// Prune values with round below 3
+	sc.PruneRoundBelow(3)
+
+	// Verify that values with round below 3 are pruned
+	_, ok := sc.cache["key1"]["hash1"]
+	require.False(t, ok)
+
+	_, ok = sc.cache["key1"]["hash2"]
+	require.False(t, ok)
+
+	_, ok = sc.cache["key1"]["hash3"]
+	require.True(t, ok)
+
+	_, ok = sc.cache["key1"]["hash4"]
+	require.True(t, ok)
+
+	sc.PrettyPrint()
+
+	// Prune values with round below 5
+	sc.PruneRoundBelow(5)
+
+	// Verify that all values are pruned
+	_, ok = sc.cache["key1"]["hash1"]
+	require.False(t, ok)
+
+	_, ok = sc.cache["key1"]["hash2"]
+	require.False(t, ok)
+
+	_, ok = sc.cache["key1"]["hash3"]
+	require.False(t, ok)
+
+	_, ok = sc.cache["key1"]["hash4"]
+	require.False(t, ok)
+	sc.PrettyPrint()
+}
+
+type Foo struct {
+	V string
+}
+
+func (f *Foo) Clone() Value {
+	return &Foo{V: f.V}
+}
+
+func (f *Foo) CopyFrom(v interface{}) bool {
+	if v, ok := v.(*Foo); ok {
+		f.V = v.V
+		return true
+	}
+	return false
+}
+
+func (f *Foo) Add() {
+
+}
+
+type Bar struct {
+}
+
+func (b *Bar) Add() {
+}
+
+type MsgInterface interface {
+	Add()
+}
+
+func TestEnableCache(t *testing.T) {
+	f := &Foo{V: "foo"}
+	fi := MsgInterface(f)
+
+	_, ok := Cacheable(fi)
+	require.True(t, ok)
+
+	b := &Bar{}
+	_, ok = Cacheable(b)
+	require.False(t, ok)
+}
+
+func TestEmptyBlockCache(t *testing.T) {
+	// Create a new state cache
+	sc := NewStateCache()
+
+	// Add a value to the state cache for a specific block
+	blockHash := "block123"
+	key := "key123"
+	value := String("value123")
+
+	bc := NewBlockCache(sc, Block{Hash: blockHash})
+	bc.Set(key, value)
+	bc.Commit()
+
+	// Create an empty block cache linked to the state cache
+	bc2 := NewBlockCache(sc, Block{Hash: blockHash})
+	_, ok := bc2.Get(key)
+	require.False(t, ok)
+}
+
+func TestStateCache_Shift(t *testing.T) {
+	sc := NewStateCache()
+
+	bc := NewBlockCache(sc, Block{Hash: "hash1"})
+	tc := NewTransactionCache(bc)
+	tc.Set("key1", String("value1"))
+	tc.Commit()
+	bc.Commit()
+
+	// Test shift method
+	for i := 2; i <= 11; i++ {
+		sc.shift("hash"+strconv.Itoa(i-1), "hash"+strconv.Itoa(i))
+	}
+
+	value, ok := sc.Get("key1", "hash11")
+	if !ok || value.(String) != "value1" {
+		t.Error("Expected value1, got ", value)
+	}
+}

--- a/core/statecache/statecache_test.go
+++ b/core/statecache/statecache_test.go
@@ -344,6 +344,29 @@ func TestTransactionCache(t *testing.T) {
 	}
 }
 
+func TestTransactionCacheRemove(t *testing.T) {
+	sc := NewStateCache()
+	bc := NewBlockCache(sc, Block{Hash: "hash1"})
+
+	tc := NewTransactionCache(bc)
+	tc.Set("key1", String("value1"))
+
+	v, ok := tc.Get("key1")
+	require.True(t, ok)
+	require.EqualValues(t, "value1", v)
+
+	// remove
+	tc.Remove("key1")
+
+	_, ok = tc.Get("key1")
+	require.False(t, ok)
+
+	tc.Commit()
+
+	_, ok = bc.Get("key1")
+	require.False(t, ok)
+}
+
 // func TestStateCache_PruneRoundBelow(t *testing.T) {
 // 	sc := NewStateCache()
 

--- a/core/statecache/statecache_test.go
+++ b/core/statecache/statecache_test.go
@@ -151,50 +151,50 @@ func TestCacheTx_SkipBlock(t *testing.T) {
 	require.EqualValues(t, "value3", v)
 }
 
-func TestCacheTx_Shift(t *testing.T) {
-	sc := NewStateCache()
-	ct := NewBlockCache(sc, Block{Hash: "hash1"})
+// func TestCacheTx_Shift(t *testing.T) {
+// 	sc := NewStateCache()
+// 	ct := NewBlockCache(sc, Block{Hash: "hash1"})
 
-	// Add values to the cache in block "hash1"
-	ct.Set("key1", String("value1_h1"))
-	ct.Set("key2", String("value2_h1"))
+// 	// Add values to the cache in block "hash1"
+// 	ct.Set("key1", String("value1_h1"))
+// 	ct.Set("key2", String("value2_h1"))
 
-	// Commit the changes to the main cache
-	ct.Commit()
+// 	// Commit the changes to the main cache
+// 	ct.Commit()
 
-	// New block that update key1 only
-	ct = NewBlockCache(sc, Block{PrevHash: "hash1", Hash: "hash2"})
-	ct.Set("key1", String("value1_h2"))
-	ct.Commit()
+// 	// New block that update key1 only
+// 	ct = NewBlockCache(sc, Block{PrevHash: "hash1", Hash: "hash2"})
+// 	ct.Set("key1", String("value1_h2"))
+// 	ct.Commit()
 
-	// Commit should trigger shift of key2 from hash1 to hash2
-	v, ok := sc.Get("key2", "hash2")
-	require.True(t, ok)
-	require.EqualValues(t, "value2_h1", v)
+// 	// Commit should trigger shift of key2 from hash1 to hash2
+// 	v, ok := sc.Get("key2", "hash2")
+// 	require.True(t, ok)
+// 	require.EqualValues(t, "value2_h1", v)
 
-	// New block to update both key1 and key2
-	ct = NewBlockCache(sc, Block{PrevHash: "hash2", Hash: "hash3"})
-	ct.Set("key1", String("value1_h3"))
-	ct.Set("key2", String("value2_h3"))
+// 	// New block to update both key1 and key2
+// 	ct = NewBlockCache(sc, Block{PrevHash: "hash2", Hash: "hash3"})
+// 	ct.Set("key1", String("value1_h3"))
+// 	ct.Set("key2", String("value2_h3"))
 
-	v1, ok := ct.Get("key1")
-	require.True(t, ok)
-	require.EqualValues(t, "value1_h3", v1)
+// 	v1, ok := ct.Get("key1")
+// 	require.True(t, ok)
+// 	require.EqualValues(t, "value1_h3", v1)
 
-	v2, ok := ct.Get("key2")
-	require.True(t, ok)
-	require.EqualValues(t, "value2_h3", v2)
+// 	v2, ok := ct.Get("key2")
+// 	require.True(t, ok)
+// 	require.EqualValues(t, "value2_h3", v2)
 
-	ct.Commit()
+// 	ct.Commit()
 
-	v1, ok = sc.Get("key1", "hash3")
-	require.True(t, ok)
-	require.EqualValues(t, "value1_h3", v1)
+// 	v1, ok = sc.Get("key1", "hash3")
+// 	require.True(t, ok)
+// 	require.EqualValues(t, "value1_h3", v1)
 
-	v2, ok = sc.Get("key2", "hash3")
-	require.True(t, ok)
-	require.EqualValues(t, "value2_h3", v2)
-}
+// 	v2, ok = sc.Get("key2", "hash3")
+// 	require.True(t, ok)
+// 	require.EqualValues(t, "value2_h3", v2)
+// }
 
 func TestConcurrentExecutionAndCommit(t *testing.T) {
 	sc := NewStateCache()

--- a/core/statecache/transactioncache.go
+++ b/core/statecache/transactioncache.go
@@ -45,7 +45,7 @@ func (tc *TransactionCache) Get(key string) (Value, bool) {
 
 	value, ok := tc.cache[key]
 	if ok {
-		logging.Logger.Debug("txn cache get", zap.String("key", key))
+		// logging.Logger.Debug("txn cache get", zap.String("key", key))
 		return value.data.Clone(), ok
 	}
 
@@ -88,14 +88,14 @@ func (tc *TransactionCache) Commit() {
 	var count int
 	for key, value := range tc.cache {
 		tc.main.setValue(key, value)
-		logging.Logger.Debug("transaction cache commit",
-			zap.String("key", key),
-			zap.Int64("round", value.round),
-			zap.Bool("deleted", value.deleted))
+		// logging.Logger.Debug("transaction cache commit",
+		// 	zap.String("key", key),
+		// 	zap.Int64("round", value.round),
+		// 	zap.Bool("deleted", value.deleted))
 		count++
 	}
 
-	logging.Logger.Debug("transaction cache commit - total", zap.Int("count", count))
+	// logging.Logger.Debug("transaction cache commit - total", zap.Int("count", count))
 
 	// Clear the transaction cache
 	tc.cache = make(map[string]valueNode)

--- a/core/statecache/transactioncache.go
+++ b/core/statecache/transactioncache.go
@@ -109,3 +109,7 @@ func (tc *TransactionCache) AddHit() {
 func (tc *TransactionCache) AddMiss() {
 	atomic.AddInt64(&tc.miss, 1)
 }
+
+func (tc *TransactionCache) Stats() (hit, miss int64) {
+	return atomic.LoadInt64(&tc.hit), atomic.LoadInt64(&tc.miss)
+}

--- a/core/statecache/transactioncache.go
+++ b/core/statecache/transactioncache.go
@@ -34,8 +34,7 @@ func (tc *TransactionCache) Set(key string, e Value) {
 
 	// logging.Logger.Debug("txn cache set", zap.String("key", key))
 	tc.cache[key] = valueNode{
-		data:  e.Clone(),
-		round: tc.round,
+		data: e.Clone(),
 	}
 }
 
@@ -78,7 +77,6 @@ func (tc *TransactionCache) Remove(key string) {
 	} else {
 		tc.cache[key] = valueNode{
 			deleted: true,
-			round:   tc.round,
 			data:    &EmptyValue{},
 		}
 	}

--- a/core/statecache/transactioncache.go
+++ b/core/statecache/transactioncache.go
@@ -22,8 +22,9 @@ func NewTransactionCache(main BlockCacher) *TransactionCache {
 	}
 }
 
-func NewEmptyTransactionCache(sc *StateCache) *TransactionCache {
-	_, tc := NewBlockTxnCaches(sc, Block{})
+// NewEmpty creates a new empty transaction cache
+func NewEmpty() *TransactionCache {
+	_, tc := NewBlockTxnCaches(NewStateCache(), Block{})
 	return tc
 }
 

--- a/core/statecache/transactioncache.go
+++ b/core/statecache/transactioncache.go
@@ -45,8 +45,11 @@ func (tc *TransactionCache) Get(key string) (Value, bool) {
 
 	value, ok := tc.cache[key]
 	if ok {
+		if value.deleted {
+			return nil, false
+		}
 		// logging.Logger.Debug("txn cache get", zap.String("key", key))
-		return value.data.Clone(), ok
+		return value.data.Clone(), true
 	}
 
 	return tc.main.Get(key)

--- a/core/statecache/transactioncache.go
+++ b/core/statecache/transactioncache.go
@@ -1,0 +1,96 @@
+package statecache
+
+import (
+	"sync"
+
+	"github.com/0chain/common/core/logging"
+	"go.uber.org/zap"
+)
+
+type TransactionCache struct {
+	main  BlockCacher
+	cache map[string]valueNode
+	mu    sync.RWMutex
+	round int64
+}
+
+func NewTransactionCache(main BlockCacher) *TransactionCache {
+	return &TransactionCache{
+		main:  main,
+		cache: make(map[string]valueNode),
+		round: main.Round(),
+	}
+}
+
+func (tc *TransactionCache) Set(key string, e Value) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+
+	logging.Logger.Debug("txn cache set", zap.String("key", key))
+	tc.cache[key] = valueNode{
+		data:  e.Clone(),
+		round: tc.round,
+	}
+}
+
+func (tc *TransactionCache) Get(key string) (Value, bool) {
+	tc.mu.RLock()
+	defer tc.mu.RUnlock()
+
+	value, ok := tc.cache[key]
+	if ok {
+		logging.Logger.Debug("txn cache get", zap.String("key", key))
+		return value.data.Clone(), ok
+	}
+
+	return tc.main.Get(key)
+}
+
+type EmptyValue struct{}
+
+func (e *EmptyValue) Clone() Value {
+	return e
+}
+
+func (e *EmptyValue) CopyFrom(interface{}) bool {
+	return true
+}
+
+func (tc *TransactionCache) Remove(key string) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	logging.Logger.Debug("txn cache remove", zap.String("key", key))
+
+	value, ok := tc.cache[key]
+	if ok {
+		value.deleted = true
+		value.data = value.data.Clone()
+		tc.cache[key] = value
+	} else {
+		tc.cache[key] = valueNode{
+			deleted: true,
+			round:   tc.round,
+			data:    &EmptyValue{},
+		}
+	}
+}
+
+func (tc *TransactionCache) Commit() {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+
+	var count int
+	for key, value := range tc.cache {
+		tc.main.setValue(key, value)
+		logging.Logger.Debug("transaction cache commit",
+			zap.String("key", key),
+			zap.Int64("round", value.round),
+			zap.Bool("deleted", value.deleted))
+		count++
+	}
+
+	logging.Logger.Debug("transaction cache commit - total", zap.Int("count", count))
+
+	// Clear the transaction cache
+	tc.cache = make(map[string]valueNode)
+}

--- a/core/statecache/transactioncache.go
+++ b/core/statecache/transactioncache.go
@@ -91,14 +91,7 @@ func (tc *TransactionCache) Commit() {
 	// var count int
 	for key, value := range tc.cache {
 		tc.main.setValue(key, value)
-		// logging.Logger.Debug("transaction cache commit",
-		// 	zap.String("key", key),
-		// 	zap.Int64("round", value.round),
-		// 	zap.Bool("deleted", value.deleted))
-		// count++
 	}
-
-	// logging.Logger.Debug("transaction cache commit - total", zap.Int("count", count))
 
 	// Clear the transaction cache
 	tc.main.addStats(tc.hit, tc.miss)

--- a/core/statecache/transactioncache.go
+++ b/core/statecache/transactioncache.go
@@ -2,9 +2,6 @@ package statecache
 
 import (
 	"sync"
-
-	"github.com/0chain/common/core/logging"
-	"go.uber.org/zap"
 )
 
 type TransactionCache struct {
@@ -32,7 +29,7 @@ func (tc *TransactionCache) Set(key string, e Value) {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 
-	logging.Logger.Debug("txn cache set", zap.String("key", key))
+	// logging.Logger.Debug("txn cache set", zap.String("key", key))
 	tc.cache[key] = valueNode{
 		data:  e.Clone(),
 		round: tc.round,
@@ -65,7 +62,7 @@ func (e *EmptyValue) CopyFrom(interface{}) bool {
 func (tc *TransactionCache) Remove(key string) {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
-	logging.Logger.Debug("txn cache remove", zap.String("key", key))
+	// logging.Logger.Debug("txn cache remove", zap.String("key", key))
 
 	value, ok := tc.cache[key]
 	if ok {

--- a/core/statecache/transactioncache.go
+++ b/core/statecache/transactioncache.go
@@ -22,6 +22,11 @@ func NewTransactionCache(main BlockCacher) *TransactionCache {
 	}
 }
 
+func NewEmptyTransactionCache(sc *StateCache) *TransactionCache {
+	_, tc := NewBlockTxnCaches(sc, Block{})
+	return tc
+}
+
 func (tc *TransactionCache) Set(key string, e Value) {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()

--- a/core/util/markle_patricia_trie_interface.go
+++ b/core/util/markle_patricia_trie_interface.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"time"
+
+	"github.com/0chain/common/core/statecache"
 )
 
 // MPTMaxAllowableNodeSize - Maximum allowable size of MPT node
@@ -66,6 +68,8 @@ type MerklePatriciaTrieI interface {
 	MergeMPTChanges(mpt2 MerklePatriciaTrieI) error
 	MergeChanges(newRoot Key, changes []*NodeChange, deletes []Node, startRoot Key) error
 	MergeDB(ndb NodeDB, root Key) error
+
+	Cache() *statecache.TransactionCache
 }
 
 // ContextKey - a type for context key

--- a/core/util/merkle_patricia_trie.go
+++ b/core/util/merkle_patricia_trie.go
@@ -19,12 +19,12 @@ import (
 	"go.uber.org/zap"
 )
 
-var findCount int64
-var missedCount int64
+// var findCount int64
+// var missedCount int64
 
-func CacheStats() (find int64, missed int64) {
-	return atomic.LoadInt64(&findCount), atomic.LoadInt64(&missedCount)
-}
+// func CacheStats() (find int64, missed int64) {
+// 	return atomic.LoadInt64(&findCount), atomic.LoadInt64(&missedCount)
+// }
 
 /*MerklePatriciaTrie - it's a merkle tree and a patricia trie */
 type MerklePatriciaTrie struct {
@@ -65,7 +65,8 @@ func (mpt *MerklePatriciaTrie) Cache() *statecache.TransactionCache {
 func (mpt *MerklePatriciaTrie) getNode(key Key) (n Node, err error) {
 	v, ok := mpt.cache.Get(string(key))
 	if ok {
-		atomic.AddInt64(&findCount, 1)
+		// atomic.AddInt64(&findCount, 1)
+		mpt.cache.AddHit()
 		// logging.Logger.Debug("MPT cache hit", zap.Int("find count", int(findCount)), zap.Int("missed count", int(missedCount)))
 		n = v.(Node)
 		return
@@ -76,7 +77,8 @@ func (mpt *MerklePatriciaTrie) getNode(key Key) (n Node, err error) {
 		mpt.addMissingNodeKeys(key)
 	}
 	if err == nil {
-		atomic.AddInt64(&missedCount, 1)
+		// atomic.AddInt64(&missedCount, 1)
+		mpt.cache.AddMiss()
 		// logging.Logger.Debug("MPT cache missed", zap.Int("find count", int(findCount)), zap.Int("missed count", int(missedCount)))
 		mpt.cache.Set(string(key), n)
 	}

--- a/core/util/merkle_patricia_trie.go
+++ b/core/util/merkle_patricia_trie.go
@@ -66,6 +66,9 @@ func (mpt *MerklePatriciaTrie) getNode(key Key) (n Node, err error) {
 	if err == ErrNodeNotFound {
 		mpt.addMissingNodeKeys(key)
 	}
+	if err == nil {
+		mpt.cache.Set(string(key), n)
+	}
 	return
 }
 

--- a/core/util/merkle_patricia_trie.go
+++ b/core/util/merkle_patricia_trie.go
@@ -677,24 +677,24 @@ func (mpt *MerklePatriciaTrie) deleteAtNode(key Key, node Node, prefix, path Pat
 	case *LeafNode:
 		if bytes.Equal(path, nodeImpl.Path) {
 			// Keep the logs until we are 100 percent sure that the MPT bug is fixed
-			logging.Logger.Debug("MPT - delete leaf node, deleteAtNode, leaf node",
-				zap.String("prefix path", ToHex(prefix)),
-				zap.String("path", ToHex(path)),
-				zap.String("node path", ToHex(nodeImpl.Path)),
-				zap.String("key", ToHex(key)),
-				zap.String("nodeImpl key", nodeImpl.GetHash()),
-				zap.Int64("node version", int64(nodeImpl.GetVersion())))
+			// logging.Logger.Debug("MPT - delete leaf node, deleteAtNode, leaf node",
+			// 	zap.String("prefix path", ToHex(prefix)),
+			// 	zap.String("path", ToHex(path)),
+			// 	zap.String("node path", ToHex(nodeImpl.Path)),
+			// 	zap.String("key", ToHex(key)),
+			// 	zap.String("nodeImpl key", nodeImpl.GetHash()),
+			// 	zap.Int64("node version", int64(nodeImpl.GetVersion())))
 			return mpt.deleteAfterPathTraversal(node)
 		}
 
 		// Keep the logs until we are 100 percent sure that the MPT bug is fixed
-		logging.Logger.Debug("MPT - value not present, deleteAtNode, leaf node, path not match",
-			zap.String("prefix path", ToHex(prefix)),
-			zap.String("path", ToHex(path)),
-			zap.String("node path", ToHex(nodeImpl.Path)),
-			zap.String("key", ToHex(key)),
-			zap.String("nodeImpl key", nodeImpl.GetHash()),
-			zap.Int64("node version", int64(nodeImpl.GetVersion())))
+		// logging.Logger.Debug("MPT - value not present, deleteAtNode, leaf node, path not match",
+		// 	zap.String("prefix path", ToHex(prefix)),
+		// 	zap.String("path", ToHex(path)),
+		// 	zap.String("node path", ToHex(nodeImpl.Path)),
+		// 	zap.String("key", ToHex(key)),
+		// 	zap.String("nodeImpl key", nodeImpl.GetHash()),
+		// 	zap.Int64("node version", int64(nodeImpl.GetVersion())))
 		return nil, nil, ErrValueNotPresent // There is nothing to delete
 	case *ExtensionNode:
 		matchPrefix := mpt.matchingPrefix(path, nodeImpl.Path)

--- a/core/util/merkle_patricia_trie.go
+++ b/core/util/merkle_patricia_trie.go
@@ -19,13 +19,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// var findCount int64
-// var missedCount int64
-
-// func CacheStats() (find int64, missed int64) {
-// 	return atomic.LoadInt64(&findCount), atomic.LoadInt64(&missedCount)
-// }
-
 /*MerklePatriciaTrie - it's a merkle tree and a patricia trie */
 type MerklePatriciaTrie struct {
 	mutex           *sync.RWMutex
@@ -65,9 +58,7 @@ func (mpt *MerklePatriciaTrie) Cache() *statecache.TransactionCache {
 func (mpt *MerklePatriciaTrie) getNode(key Key) (n Node, err error) {
 	v, ok := mpt.cache.Get(string(key))
 	if ok {
-		// atomic.AddInt64(&findCount, 1)
 		mpt.cache.AddHit()
-		// logging.Logger.Debug("MPT cache hit", zap.Int("find count", int(findCount)), zap.Int("missed count", int(missedCount)))
 		n = v.(Node)
 		return
 	}
@@ -77,9 +68,7 @@ func (mpt *MerklePatriciaTrie) getNode(key Key) (n Node, err error) {
 		mpt.addMissingNodeKeys(key)
 	}
 	if err == nil {
-		// atomic.AddInt64(&missedCount, 1)
 		mpt.cache.AddMiss()
-		// logging.Logger.Debug("MPT cache missed", zap.Int("find count", int(findCount)), zap.Int("missed count", int(missedCount)))
 		mpt.cache.Set(string(key), n)
 	}
 	return
@@ -678,25 +667,9 @@ func (mpt *MerklePatriciaTrie) deleteAtNode(key Key, node Node, prefix, path Pat
 		return mpt.insertNode(node, nnode)
 	case *LeafNode:
 		if bytes.Equal(path, nodeImpl.Path) {
-			// Keep the logs until we are 100 percent sure that the MPT bug is fixed
-			// logging.Logger.Debug("MPT - delete leaf node, deleteAtNode, leaf node",
-			// 	zap.String("prefix path", ToHex(prefix)),
-			// 	zap.String("path", ToHex(path)),
-			// 	zap.String("node path", ToHex(nodeImpl.Path)),
-			// 	zap.String("key", ToHex(key)),
-			// 	zap.String("nodeImpl key", nodeImpl.GetHash()),
-			// 	zap.Int64("node version", int64(nodeImpl.GetVersion())))
 			return mpt.deleteAfterPathTraversal(node)
 		}
 
-		// Keep the logs until we are 100 percent sure that the MPT bug is fixed
-		// logging.Logger.Debug("MPT - value not present, deleteAtNode, leaf node, path not match",
-		// 	zap.String("prefix path", ToHex(prefix)),
-		// 	zap.String("path", ToHex(path)),
-		// 	zap.String("node path", ToHex(nodeImpl.Path)),
-		// 	zap.String("key", ToHex(key)),
-		// 	zap.String("nodeImpl key", nodeImpl.GetHash()),
-		// 	zap.Int64("node version", int64(nodeImpl.GetVersion())))
 		return nil, nil, ErrValueNotPresent // There is nothing to delete
 	case *ExtensionNode:
 		matchPrefix := mpt.matchingPrefix(path, nodeImpl.Path)

--- a/core/util/merkle_patricia_trie.go
+++ b/core/util/merkle_patricia_trie.go
@@ -22,6 +22,10 @@ import (
 var findCount int64
 var missedCount int64
 
+func CacheStats() (find int64, missed int64) {
+	return atomic.LoadInt64(&findCount), atomic.LoadInt64(&missedCount)
+}
+
 /*MerklePatriciaTrie - it's a merkle tree and a patricia trie */
 type MerklePatriciaTrie struct {
 	mutex           *sync.RWMutex
@@ -62,7 +66,7 @@ func (mpt *MerklePatriciaTrie) getNode(key Key) (n Node, err error) {
 	v, ok := mpt.cache.Get(string(key))
 	if ok {
 		atomic.AddInt64(&findCount, 1)
-		logging.Logger.Debug("MPT cache hit", zap.Int("find count", int(findCount)), zap.Int("missed count", int(missedCount)))
+		// logging.Logger.Debug("MPT cache hit", zap.Int("find count", int(findCount)), zap.Int("missed count", int(missedCount)))
 		n = v.(Node)
 		return
 	}
@@ -73,7 +77,7 @@ func (mpt *MerklePatriciaTrie) getNode(key Key) (n Node, err error) {
 	}
 	if err == nil {
 		atomic.AddInt64(&missedCount, 1)
-		logging.Logger.Debug("MPT cache missed", zap.Int("find count", int(findCount)), zap.Int("missed count", int(missedCount)))
+		// logging.Logger.Debug("MPT cache missed", zap.Int("find count", int(findCount)), zap.Int("missed count", int(missedCount)))
 		mpt.cache.Set(string(key), n)
 	}
 	return

--- a/core/util/merkle_patricia_trie.go
+++ b/core/util/merkle_patricia_trie.go
@@ -51,6 +51,10 @@ func CloneMPT(mpt MerklePatriciaTrieI) *MerklePatriciaTrie {
 	return clone
 }
 
+func (mpt *MerklePatriciaTrie) Cache() *statecache.TransactionCache {
+	return mpt.cache
+}
+
 func (mpt *MerklePatriciaTrie) getNode(key Key) (n Node, err error) {
 	v, ok := mpt.cache.Get(string(key))
 	if ok {

--- a/core/util/merkle_patricia_trie.go
+++ b/core/util/merkle_patricia_trie.go
@@ -899,6 +899,8 @@ func (mpt *MerklePatriciaTrie) insertNode(oldNode Node, newNode Node) (Node, Key
 			if err := mpt.db.DeleteNode(okey); err != nil {
 				return nil, nil, err
 			}
+
+			mpt.cache.Remove(string(okey))
 		}
 	}
 	return newNode, ckey, nil
@@ -911,8 +913,12 @@ func (mpt *MerklePatriciaTrie) deleteNode(node Node) error {
 	//Logger.Debug("delete node", zap.Any("version", mpt.Version), zap.String("key", node.GetHash()))
 	mpt.ChangeCollector.DeleteChange(node)
 	ckey := node.GetHashBytes()
+	err := mpt.db.DeleteNode(ckey)
+	if err != nil {
+		return err
+	}
 	mpt.cache.Remove(string(ckey))
-	return mpt.db.DeleteNode(ckey)
+	return nil
 }
 
 func (mpt *MerklePatriciaTrie) matchingPrefix(p1 Path, p2 Path) Path {

--- a/core/util/merkle_patricia_trie_mocks_test.go
+++ b/core/util/merkle_patricia_trie_mocks_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/0chain/common/core/logging"
 	"github.com/0chain/common/core/mocks"
+	"github.com/0chain/common/core/statecache"
 	. "github.com/0chain/common/core/util"
 	"github.com/stretchr/testify/mock"
 )
@@ -21,7 +22,7 @@ func init() {
 func TestMPTSaveChanges(t *testing.T) {
 	mockNodeDB1 := &mocks.NodeDB{}
 	mockNodeDB1.On("PutNode", mock.Anything, mock.Anything).Return(nil)
-	mpt := NewMerklePatriciaTrie(mockNodeDB1, Sequence(0), nil)
+	mpt := NewMerklePatriciaTrie(mockNodeDB1, Sequence(0), nil, statecache.NewEmpty())
 	_, err := mpt.Insert(Path("key"), &Txn{"value"})
 	require.NoError(t, err)
 	mockNodeDB2 := &mocks.NodeDB{}

--- a/core/util/merkle_patricia_trie_test.go
+++ b/core/util/merkle_patricia_trie_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"encoding/json"
@@ -177,12 +178,12 @@ func TestMerkleTreePruningReopenDB(t *testing.T) {
 }
 
 func testPruneState(t *testing.T, pndb *PNodeDB) {
-	mpt := NewMerklePatriciaTrie(NewLevelNodeDB(NewMemoryNodeDB(), pndb, false), Sequence(0), nil)
+	mpt := NewMerklePatriciaTrie(NewLevelNodeDB(NewMemoryNodeDB(), pndb, false), Sequence(0), nil, statecache.NewEmpty())
 	origin := 2016
 	roots := make([]Key, 0, 10)
 
 	db := NewLevelNodeDB(NewMemoryNodeDB(), mpt.db, false)
-	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), mpt.GetRoot())
+	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), mpt.GetRoot(), statecache.NewEmpty())
 	totalDelete := 0
 	numStates := 100
 
@@ -215,7 +216,7 @@ func testPruneState(t *testing.T, pndb *PNodeDB) {
 
 	newOrigin := origin - numStates
 	root := roots[len(roots)-numStates]
-	mpt = NewMerklePatriciaTrie(mpt.GetNodeDB(), mpt.GetVersion(), root)
+	mpt = NewMerklePatriciaTrie(mpt.GetNodeDB(), mpt.GetVersion(), root, statecache.NewEmpty())
 
 	checkIterationHash(t, mpt, "7678d38296cab5f5eb34000e5c0d9718cf79ec82949a1cbd65ce46e676199127")
 
@@ -282,7 +283,7 @@ func TestMPT_blockGenerationFlow(t *testing.T) {
 	var stateDB, cleanup = newPNodeDB(t)
 	defer cleanup()
 
-	var mpt = NewMerklePatriciaTrie(stateDB, 0, nil)
+	var mpt = NewMerklePatriciaTrie(stateDB, 0, nil, statecache.NewEmpty())
 	// prior block DB and hash
 	var (
 		priorDB   NodeDB = stateDB
@@ -325,7 +326,7 @@ func TestMPT_blockGenerationFlow(t *testing.T) {
 		//
 		var (
 			ndb        = NewLevelNodeDB(NewMemoryNodeDB(), priorDB, false)
-			blockState = NewMerklePatriciaTrie(ndb, Sequence(round), priorHash)
+			blockState = NewMerklePatriciaTrie(ndb, Sequence(round), priorHash, statecache.NewEmpty())
 			err        error
 		)
 
@@ -334,7 +335,7 @@ func TestMPT_blockGenerationFlow(t *testing.T) {
 		//
 		var (
 			tdb  = NewLevelNodeDB(NewMemoryNodeDB(), blockState.GetNodeDB(), false)
-			tmpt = NewMerklePatriciaTrie(tdb, blockState.GetVersion(), blockState.GetRoot())
+			tmpt = NewMerklePatriciaTrie(tdb, blockState.GetVersion(), blockState.GetRoot(), statecache.NewEmpty())
 		)
 
 		//
@@ -377,16 +378,16 @@ func TestMPT_blockGenerationFlow(t *testing.T) {
 
 		checkValues(t, blockState, expectedValueSets[round])
 		require.NoError(t, blockState.SaveChanges(context.TODO(), stateDB, false))
-		mpt = NewMerklePatriciaTrie(mpt.GetNodeDB(), mpt.GetVersion(), priorHash)
+		mpt = NewMerklePatriciaTrie(mpt.GetNodeDB(), mpt.GetVersion(), priorHash, statecache.NewEmpty())
 		checkValues(t, mpt, expectedValueSets[round])
 	}
 }
 
 func TestMPTHexachars(t *testing.T) {
 	mndb := NewMemoryNodeDB()
-	mpt := NewMerklePatriciaTrie(mndb, Sequence(2018), nil)
+	mpt := NewMerklePatriciaTrie(mndb, Sequence(2018), nil, statecache.NewEmpty())
 	db := NewLevelNodeDB(NewMemoryNodeDB(), mpt.db, false)
-	var mpt2 MerklePatriciaTrieI = NewMerklePatriciaTrie(db, Sequence(2018), mpt.GetRoot())
+	var mpt2 MerklePatriciaTrieI = NewMerklePatriciaTrie(db, Sequence(2018), mpt.GetRoot(), statecache.NewEmpty())
 
 	doStrValInsert(t, mpt2, "01", "1")
 	doStrValInsert(t, mpt2, "02", "2")
@@ -395,9 +396,9 @@ func TestMPTHexachars(t *testing.T) {
 
 func TestMPTInsertLeafNode(t *testing.T) {
 	mndb := NewMemoryNodeDB()
-	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil)
+	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil, statecache.NewEmpty())
 	db := NewLevelNodeDB(NewMemoryNodeDB(), mpt.db, false)
-	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), mpt.GetRoot())
+	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), mpt.GetRoot(), statecache.NewEmpty())
 
 	doStrValInsert(t, mpt2, "1234", "1")
 	doStrValInsert(t, mpt2, "123567", "2")
@@ -406,7 +407,7 @@ func TestMPTInsertLeafNode(t *testing.T) {
 	doStrValInsert(t, mpt2, "12381234", "5")
 	doStrValInsert(t, mpt2, "12391234", "6")
 
-	_, err := mpt2.GetPathNodes(Path("12391234"))
+	_, err := mpt2.GetNodeValueRaw(Path("12391234"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -424,9 +425,9 @@ func TestMPTInsertLeafNode(t *testing.T) {
 
 func TestMPTInsertFullNode(t *testing.T) {
 	mndb := NewMemoryNodeDB()
-	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil)
+	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil, statecache.NewEmpty())
 	db := NewLevelNodeDB(NewMemoryNodeDB(), mpt.db, false)
-	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), mpt.GetRoot())
+	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), mpt.GetRoot(), statecache.NewEmpty())
 
 	doStrValInsert(t, mpt2, "01", "1")
 	doStrValInsert(t, mpt2, "02", "2")
@@ -441,9 +442,9 @@ func TestMPTInsertFullNode(t *testing.T) {
 
 func TestMPTInsertExtensionNode(t *testing.T) {
 	mndb := NewMemoryNodeDB()
-	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil)
+	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil, statecache.NewEmpty())
 	db := NewLevelNodeDB(NewMemoryNodeDB(), mpt.db, false)
-	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), mpt.GetRoot())
+	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), mpt.GetRoot(), statecache.NewEmpty())
 
 	doStrValInsert(t, mpt2, "123456", "12345")
 	doStrValInsert(t, mpt2, "123467", "12346")
@@ -499,9 +500,9 @@ func TestMPTInsertExtensionNode(t *testing.T) {
 
 func TestMPTRepetitiveInsert(t *testing.T) {
 	mndb := NewMemoryNodeDB()
-	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil)
+	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil, statecache.NewEmpty())
 	db := NewLevelNodeDB(NewMemoryNodeDB(), mpt.db, false)
-	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), mpt.GetRoot())
+	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), mpt.GetRoot(), statecache.NewEmpty())
 
 	doStrValInsert(t, mpt2, "223456", "22345")
 	doStrValInsert(t, mpt2, "223467", "22346")
@@ -519,7 +520,7 @@ func TestMPTRepetitiveInsert(t *testing.T) {
 func TestMPT_MultipleConcurrentInserts(t *testing.T) {
 	//t.Parallel()
 	db := NewLevelNodeDB(NewMemoryNodeDB(), NewMemoryNodeDB(), false)
-	mpt := NewMerklePatriciaTrie(db, Sequence(0), nil)
+	mpt := NewMerklePatriciaTrie(db, Sequence(0), nil, statecache.NewEmpty())
 	ldb := NewLevelNodeDB(NewMemoryNodeDB(), db, false)
 	numGoRoutines := 10
 	numTxns := 100
@@ -533,7 +534,7 @@ func TestMPT_MultipleConcurrentInserts(t *testing.T) {
 		require.NoError(t, err)
 	}
 	checkIterationHash(t, mpt, "6e7eabd0548a424b78bf2c4393a15c42e42fac1287be0e3723dcb31e720b53ec")
-	mpt2 := NewMerklePatriciaTrie(ldb, Sequence(0), mpt.GetRoot())
+	mpt2 := NewMerklePatriciaTrie(ldb, Sequence(0), mpt.GetRoot(), statecache.NewEmpty())
 	checkIterationHash(t, mpt2, "6e7eabd0548a424b78bf2c4393a15c42e42fac1287be0e3723dcb31e720b53ec")
 	wg := &sync.WaitGroup{}
 	for i := 0; i < numGoRoutines; i++ {
@@ -555,9 +556,9 @@ func TestMPT_MultipleConcurrentInserts(t *testing.T) {
 
 func TestMPTDelete(t *testing.T) {
 	mndb := NewMemoryNodeDB()
-	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil)
+	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil, statecache.NewEmpty())
 	db := NewLevelNodeDB(NewMemoryNodeDB(), mpt.db, false)
-	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), mpt.GetRoot())
+	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), mpt.GetRoot(), statecache.NewEmpty())
 
 	doStrValInsert(t, mpt2, "123456", "12345")
 	doStrValInsert(t, mpt2, "223456", "22345")
@@ -600,9 +601,9 @@ func TestMPTDelete(t *testing.T) {
 
 func TestMPTUniverse(t *testing.T) {
 	mndb := NewMemoryNodeDB()
-	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil)
+	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil, statecache.NewEmpty())
 	db := NewLevelNodeDB(NewMemoryNodeDB(), mpt.db, false)
-	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), mpt.GetRoot())
+	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), mpt.GetRoot(), statecache.NewEmpty())
 
 	doStrValInsert(t, mpt2, "01234513", "earth")
 	doStrValInsert(t, mpt2, "0123451478", "mars")
@@ -664,9 +665,9 @@ func TestMPTUniverse(t *testing.T) {
 
 func TestMPTInsertEthereumExample(t *testing.T) {
 	mndb := NewMemoryNodeDB()
-	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil)
+	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil, statecache.NewEmpty())
 	db := NewLevelNodeDB(NewMemoryNodeDB(), mpt.db, false)
-	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), mpt.GetRoot())
+	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), mpt.GetRoot(), statecache.NewEmpty())
 
 	doStrValInsert(t, mpt2, "646f", "verb")
 	doStrValInsert(t, mpt2, "646f67", "puppy")
@@ -850,9 +851,9 @@ merge extensions : delete L from P(E(F(L,E))) and ensure P(E(F(E))) becomes P(E)
 */
 func TestCasePEFLEdeleteL(t *testing.T) {
 	mndb := NewMemoryNodeDB()
-	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil)
+	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil, statecache.NewEmpty())
 	db := NewLevelNodeDB(NewMemoryNodeDB(), mpt.db, false)
-	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), nil)
+	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), nil, statecache.NewEmpty())
 
 	doStrValInsert(t, mpt2, "22345678", "mercury")
 	doStrValInsert(t, mpt2, "1235", "venus")
@@ -919,9 +920,9 @@ func TestCasePEFLEdeleteL(t *testing.T) {
 
 func TestAddTwiceDeleteOnce(t *testing.T) {
 	mndb := NewMemoryNodeDB()
-	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil)
+	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil, statecache.NewEmpty())
 	db := NewLevelNodeDB(NewMemoryNodeDB(), mpt.db, false)
-	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), nil)
+	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), nil, statecache.NewEmpty())
 
 	doStrValInsert(t, mpt2, "1234567812", "x")
 	doStrValInsert(t, mpt2, "1234567822", "y")
@@ -995,7 +996,7 @@ func TestGetPruneStats(t *testing.T) {
 
 func TestCloneMPT(t *testing.T) {
 	mndb := NewMemoryNodeDB()
-	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil)
+	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil, statecache.NewEmpty())
 
 	type args struct {
 		mpt MerklePatriciaTrieI
@@ -1041,13 +1042,13 @@ func (u *User) UnmarshalMsg(bytes []byte) ([]byte, error) {
 
 func TestCloneMPT2(t *testing.T) {
 	mndb := NewMemoryNodeDB()
-	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil)
+	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil, statecache.NewEmpty())
 
 	if _, err := mpt.Insert([]byte("aaa"), &User{}); err != nil {
 		t.Error(err)
 	}
 
-	mpt1 := NewMerklePatriciaTrie(mndb, Sequence(1), mpt.root)
+	mpt1 := NewMerklePatriciaTrie(mndb, Sequence(1), mpt.root, statecache.NewEmpty())
 
 	type args struct {
 		mpt MerklePatriciaTrieI
@@ -1070,7 +1071,7 @@ func TestCloneMPT2(t *testing.T) {
 			if _, err := mpt1.Insert([]byte("bbb"), &User{Age: 1}); err != nil {
 				t.Error(err)
 			}
-			mpt2 := NewMerklePatriciaTrie(mndb, Sequence(1), mpt.root)
+			mpt2 := NewMerklePatriciaTrie(mndb, Sequence(1), mpt.root, statecache.NewEmpty())
 
 			if !reflect.DeepEqual(got, mpt2) {
 				t.Errorf("CloneMPT() = %v, want %v", got, mpt2)
@@ -1084,7 +1085,7 @@ func TestMerklePatriciaTrie_SetNodeDB(t *testing.T) {
 
 	mndb := NewMemoryNodeDB()
 	mndb1 := NewLevelNodeDB(NewMemoryNodeDB(), NewMemoryNodeDB(), false)
-	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil)
+	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil, statecache.NewEmpty())
 
 	type fields struct {
 		mutex           *sync.RWMutex
@@ -1137,7 +1138,7 @@ func TestMerklePatriciaTrie_getNodeDB(t *testing.T) {
 	t.Parallel()
 
 	mndb := NewMemoryNodeDB()
-	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil)
+	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil, statecache.NewEmpty())
 
 	type fields struct {
 		mutex           *sync.RWMutex
@@ -1185,7 +1186,7 @@ func TestMerklePatriciaTrie_GetNodeValue(t *testing.T) {
 	pdb, cleanup := newPNodeDB(t)
 	defer cleanup()
 
-	pmpt := NewMerklePatriciaTrie(pdb, 0, Key("qwe"))
+	pmpt := NewMerklePatriciaTrie(pdb, 0, Key("qwe"), statecache.NewEmpty())
 
 	// case 2
 
@@ -1193,7 +1194,7 @@ func TestMerklePatriciaTrie_GetNodeValue(t *testing.T) {
 	key := "key"
 	mdb.Nodes[StrKey(key)] = nil
 
-	mmpt := NewMerklePatriciaTrie(mdb, 0, Key("key"))
+	mmpt := NewMerklePatriciaTrie(mdb, 0, Key("key"), statecache.NewEmpty())
 
 	type fields struct {
 		mutex           *sync.RWMutex
@@ -1321,159 +1322,159 @@ func TestMerklePatriciaTrie_Insert(t *testing.T) {
 
 }
 
-func TestMerklePatriciaTrie_GetPathNodes(t *testing.T) {
-	t.Parallel()
+// func TestMerklePatriciaTrie_GetPathNodes(t *testing.T) {
+// 	t.Parallel()
 
-	type fields struct {
-		mutex           *sync.RWMutex
-		Root            Key
-		db              NodeDB
-		ChangeCollector ChangeCollectorI
-		Version         Sequence
-	}
-	type args struct {
-		path Path
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    []Node
-		wantErr bool
-	}{
-		{
-			name:    "Test_MerklePatriciaTrie_GetPathNodes_OK",
-			fields:  fields{mutex: &sync.RWMutex{}, db: NewMemoryNodeDB()},
-			args:    args{path: Path("path")},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+// 	type fields struct {
+// 		mutex           *sync.RWMutex
+// 		Root            Key
+// 		db              NodeDB
+// 		ChangeCollector ChangeCollectorI
+// 		Version         Sequence
+// 	}
+// 	type args struct {
+// 		path Path
+// 	}
+// 	tests := []struct {
+// 		name    string
+// 		fields  fields
+// 		args    args
+// 		want    []Node
+// 		wantErr bool
+// 	}{
+// 		{
+// 			name:    "Test_MerklePatriciaTrie_GetPathNodes_OK",
+// 			fields:  fields{mutex: &sync.RWMutex{}, db: NewMemoryNodeDB()},
+// 			args:    args{path: Path("path")},
+// 			wantErr: true,
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		tt := tt
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			t.Parallel()
 
-			mpt := &MerklePatriciaTrie{
-				mutex:           tt.fields.mutex,
-				root:            tt.fields.Root,
-				db:              tt.fields.db,
-				ChangeCollector: tt.fields.ChangeCollector,
-				Version:         tt.fields.Version,
-			}
-			got, err := mpt.GetPathNodes(tt.args.path)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("GetPathNodes() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetPathNodes() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
+// 			mpt := &MerklePatriciaTrie{
+// 				mutex:           tt.fields.mutex,
+// 				root:            tt.fields.Root,
+// 				db:              tt.fields.db,
+// 				ChangeCollector: tt.fields.ChangeCollector,
+// 				Version:         tt.fields.Version,
+// 			}
+// 			got, err := mpt.GetNodeValueRaw(tt.args.path)
+// 			if (err != nil) != tt.wantErr {
+// 				t.Errorf("GetPathNodes() error = %v, wantErr %v", err, tt.wantErr)
+// 				return
+// 			}
+// 			if !reflect.DeepEqual(got, tt.want) {
+// 				t.Errorf("GetPathNodes() got = %v, want %v", got, tt.want)
+// 			}
+// 		})
+// 	}
+// }
 
-func TestMerklePatriciaTrie_getPathNodes(t *testing.T) {
-	t.Parallel()
+// func TestMerklePatriciaTrie_getPathNodes(t *testing.T) {
+// 	t.Parallel()
 
-	fn := NewFullNode(&SecureSerializableValue{Buffer: []byte("fn data")})
-	keyFn := Key(fn.GetHash())
-	fn1 := NewFullNode(&SecureSerializableValue{Buffer: []byte("data")})
-	keyFn1 := Key(fn1.GetHash())
-	fn1.Children[0] = NewFullNode(&SecureSerializableValue{Buffer: []byte("children data")}).Encode()
+// 	fn := NewFullNode(&SecureSerializableValue{Buffer: []byte("fn data")})
+// 	keyFn := Key(fn.GetHash())
+// 	fn1 := NewFullNode(&SecureSerializableValue{Buffer: []byte("data")})
+// 	keyFn1 := Key(fn1.GetHash())
+// 	fn1.Children[0] = NewFullNode(&SecureSerializableValue{Buffer: []byte("children data")}).Encode()
 
-	ln := NewLeafNode(Path(""), Path("path"), 0, &SecureSerializableValue{Buffer: []byte("ln data")})
-	keyLn := Key(ln.GetHash())
+// 	ln := NewLeafNode(Path(""), Path("path"), 0, &SecureSerializableValue{Buffer: []byte("ln data")})
+// 	keyLn := Key(ln.GetHash())
 
-	keyEn := Key("key")
-	en := NewExtensionNode(Path("path"), keyEn)
+// 	keyEn := Key("key")
+// 	en := NewExtensionNode(Path("path"), keyEn)
 
-	db := NewMemoryNodeDB()
-	err := db.PutNode(keyFn, fn)
-	require.NoError(t, err)
-	err = db.PutNode(keyFn1, fn1)
-	require.NoError(t, err)
-	err = db.PutNode(keyLn, ln)
-	require.NoError(t, err)
-	err = db.PutNode(keyEn, en)
-	require.NoError(t, err)
+// 	db := NewMemoryNodeDB()
+// 	err := db.PutNode(keyFn, fn)
+// 	require.NoError(t, err)
+// 	err = db.PutNode(keyFn1, fn1)
+// 	require.NoError(t, err)
+// 	err = db.PutNode(keyLn, ln)
+// 	require.NoError(t, err)
+// 	err = db.PutNode(keyEn, en)
+// 	require.NoError(t, err)
 
-	type fields struct {
-		mutex           *sync.RWMutex
-		Root            Key
-		db              NodeDB
-		ChangeCollector ChangeCollectorI
-		Version         Sequence
-	}
-	type args struct {
-		key  Key
-		path Path
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    []Node
-		wantErr bool
-	}{
-		{
-			name:    "Test_MerklePatriciaTrie_getPathNodes_Path_With_Zero_Length_OK",
-			want:    nil,
-			wantErr: false,
-		},
-		{
-			name:    "Test_MerklePatriciaTrie_getPathNodes_Leaf_Node_Value_Not_Present_ERR",
-			fields:  fields{mutex: &sync.RWMutex{}, db: db},
-			args:    args{key: keyLn, path: Path("0")},
-			wantErr: true,
-		},
-		{
-			name:    "Test_MerklePatriciaTrie_getPathNodes_Full_Node_Value_Not_Present_ERR",
-			fields:  fields{mutex: &sync.RWMutex{}, db: db},
-			args:    args{key: keyFn, path: Path("0")},
-			wantErr: true,
-		},
-		{
-			name:    "Test_MerklePatriciaTrie_getPathNodes_Full_Node_Children_Value_Not_Present_ERR",
-			fields:  fields{db: db, mutex: &sync.RWMutex{}},
-			args:    args{key: keyFn1, path: Path("0123")},
-			wantErr: true,
-		},
-		{
-			name:    "Test_MerklePatriciaTrie_getPathNodes_Extension_Node_Value_Not_Present_ERR",
-			fields:  fields{mutex: &sync.RWMutex{}, db: db},
-			args:    args{key: keyEn, path: Path("0")},
-			wantErr: true,
-		},
-		{
-			name:    "Test_MerklePatriciaTrie_getPathNodes_Extension_Node_ERR",
-			fields:  fields{mutex: &sync.RWMutex{}, db: db},
-			args:    args{key: keyEn, path: Path("path:123")},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+// 	type fields struct {
+// 		mutex           *sync.RWMutex
+// 		Root            Key
+// 		db              NodeDB
+// 		ChangeCollector ChangeCollectorI
+// 		Version         Sequence
+// 	}
+// 	type args struct {
+// 		key  Key
+// 		path Path
+// 	}
+// 	tests := []struct {
+// 		name    string
+// 		fields  fields
+// 		args    args
+// 		want    []Node
+// 		wantErr bool
+// 	}{
+// 		{
+// 			name:    "Test_MerklePatriciaTrie_getPathNodes_Path_With_Zero_Length_OK",
+// 			want:    nil,
+// 			wantErr: false,
+// 		},
+// 		{
+// 			name:    "Test_MerklePatriciaTrie_getPathNodes_Leaf_Node_Value_Not_Present_ERR",
+// 			fields:  fields{mutex: &sync.RWMutex{}, db: db},
+// 			args:    args{key: keyLn, path: Path("0")},
+// 			wantErr: true,
+// 		},
+// 		{
+// 			name:    "Test_MerklePatriciaTrie_getPathNodes_Full_Node_Value_Not_Present_ERR",
+// 			fields:  fields{mutex: &sync.RWMutex{}, db: db},
+// 			args:    args{key: keyFn, path: Path("0")},
+// 			wantErr: true,
+// 		},
+// 		{
+// 			name:    "Test_MerklePatriciaTrie_getPathNodes_Full_Node_Children_Value_Not_Present_ERR",
+// 			fields:  fields{db: db, mutex: &sync.RWMutex{}},
+// 			args:    args{key: keyFn1, path: Path("0123")},
+// 			wantErr: true,
+// 		},
+// 		{
+// 			name:    "Test_MerklePatriciaTrie_getPathNodes_Extension_Node_Value_Not_Present_ERR",
+// 			fields:  fields{mutex: &sync.RWMutex{}, db: db},
+// 			args:    args{key: keyEn, path: Path("0")},
+// 			wantErr: true,
+// 		},
+// 		{
+// 			name:    "Test_MerklePatriciaTrie_getPathNodes_Extension_Node_ERR",
+// 			fields:  fields{mutex: &sync.RWMutex{}, db: db},
+// 			args:    args{key: keyEn, path: Path("path:123")},
+// 			wantErr: true,
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		tt := tt
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			t.Parallel()
 
-			mpt := &MerklePatriciaTrie{
-				mutex:           tt.fields.mutex,
-				root:            tt.fields.Root,
-				db:              tt.fields.db,
-				ChangeCollector: tt.fields.ChangeCollector,
-				Version:         tt.fields.Version,
-			}
-			got, err := mpt.getPathNodes(tt.args.key, tt.args.path)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("getPathNodes() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getPathNodes() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
+// 			mpt := &MerklePatriciaTrie{
+// 				mutex:           tt.fields.mutex,
+// 				root:            tt.fields.Root,
+// 				db:              tt.fields.db,
+// 				ChangeCollector: tt.fields.ChangeCollector,
+// 				Version:         tt.fields.Version,
+// 			}
+// 			got, err := mpt.getPathNodes(tt.args.key, tt.args.path)
+// 			if (err != nil) != tt.wantErr {
+// 				t.Errorf("getPathNodes() error = %v, wantErr %v", err, tt.wantErr)
+// 				return
+// 			}
+// 			if !reflect.DeepEqual(got, tt.want) {
+// 				t.Errorf("getPathNodes() got = %v, want %v", got, tt.want)
+// 			}
+// 		})
+// 	}
+// }
 
 func TestMerklePatriciaTrie_Iterate(t *testing.T) {
 	t.Parallel()
@@ -1814,10 +1815,10 @@ func TestMerklePatriciaTrie_insertAtNode(t *testing.T) {
 func TestMerklePatriciaTrie_MergeChanges(t *testing.T) {
 	t.Parallel()
 
-	mpt := NewMerklePatriciaTrie(NewMemoryNodeDB(), 0, nil)
+	mpt := NewMerklePatriciaTrie(NewMemoryNodeDB(), 0, nil, statecache.NewEmpty())
 
 	mndb := NewMemoryNodeDB()
-	mpt2 := NewMerklePatriciaTrie(mndb, 0, nil)
+	mpt2 := NewMerklePatriciaTrie(mndb, 0, nil, statecache.NewEmpty())
 	doStrValInsert(t, mpt2, "1234", "test")
 
 	type fields struct {
@@ -1873,7 +1874,7 @@ func TestMerklePatriciaTrie_MergeMPTChanges(t *testing.T) {
 	DebugMPTNode = true
 
 	db := NewLevelNodeDB(NewMemoryNodeDB(), NewMemoryNodeDB(), true)
-	mpt := NewMerklePatriciaTrie(db, 0, nil)
+	mpt := NewMerklePatriciaTrie(db, 0, nil, statecache.NewEmpty())
 
 	type fields struct {
 		mutex           *sync.RWMutex
@@ -1900,7 +1901,7 @@ func TestMerklePatriciaTrie_MergeMPTChanges(t *testing.T) {
 				ChangeCollector: mpt.ChangeCollector,
 				Version:         mpt.Version,
 			},
-			args:    args{mpt2: NewMerklePatriciaTrie(NewMemoryNodeDB(), 0, nil)},
+			args:    args{mpt2: NewMerklePatriciaTrie(NewMemoryNodeDB(), 0, nil, statecache.NewEmpty())},
 			wantErr: false,
 		},
 		{
@@ -1913,7 +1914,7 @@ func TestMerklePatriciaTrie_MergeMPTChanges(t *testing.T) {
 				Version:         mpt.Version,
 			},
 			args: func() args {
-				mpt := NewMerklePatriciaTrie(NewMemoryNodeDB(), 0, Key("key"))
+				mpt := NewMerklePatriciaTrie(NewMemoryNodeDB(), 0, Key("key"), statecache.NewEmpty())
 
 				cc := &ChangeCollector{
 					Changes: make(map[string]*NodeChange),
@@ -1940,7 +1941,7 @@ func TestMerklePatriciaTrie_MergeMPTChanges(t *testing.T) {
 				mpt2: func() *MerklePatriciaTrie {
 					mpt := NewMerklePatriciaTrie(
 						NewLevelNodeDB(NewMemoryNodeDB(), NewMemoryNodeDB(), false),
-						0, Key("key"),
+						0, Key("key"), statecache.NewEmpty(),
 					)
 
 					return mpt
@@ -1969,7 +1970,7 @@ func TestMerklePatriciaTrie_MergeMPTChanges(t *testing.T) {
 func TestMerklePatriciaTrie_IntegrityAfterValueUpdate(t *testing.T) {
 	t.Parallel()
 	db := NewLevelNodeDB(NewMemoryNodeDB(), NewMemoryNodeDB(), false)
-	mpt := NewMerklePatriciaTrie(db, Sequence(0), nil)
+	mpt := NewMerklePatriciaTrie(db, Sequence(0), nil, statecache.NewEmpty())
 	txn := &Txn{"1"}
 
 	_, err := mpt.Insert(Path("00"), txn)
@@ -1990,7 +1991,7 @@ func TestMerklePatriciaTrie_Validate(t *testing.T) {
 	pndb, cleanup := newPNodeDB(t)
 	defer cleanup()
 
-	mpt := NewMerklePatriciaTrie(nil, 0, nil)
+	mpt := NewMerklePatriciaTrie(nil, 0, nil, statecache.NewEmpty())
 
 	lndb := NewLevelNodeDB(NewMemoryNodeDB(), NewMemoryNodeDB(), true)
 	n := NewFullNode(&SecureSerializableValue{Buffer: []byte("value")})
@@ -2100,7 +2101,7 @@ func TestIsMPTValid(t *testing.T) {
 	}{
 		{
 			name:    "Test_IsMPTValid_OK",
-			args:    args{mpt: NewMerklePatriciaTrie(NewMemoryNodeDB(), 0, nil)},
+			args:    args{mpt: NewMerklePatriciaTrie(NewMemoryNodeDB(), 0, nil, statecache.NewEmpty())},
 			wantErr: false,
 		},
 	}
@@ -2118,9 +2119,9 @@ func TestIsMPTValid(t *testing.T) {
 
 func TestMPTInsertABC(t *testing.T) {
 	mndb := NewMemoryNodeDB()
-	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil)
+	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil, statecache.NewEmpty())
 	db := NewLevelNodeDB(NewMemoryNodeDB(), mpt.db, false)
-	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), nil)
+	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), nil, statecache.NewEmpty())
 
 	doStrValInsert(t, mpt2, "12345897", "earth")
 	doStrValInsert(t, mpt2, "1234", "mars")
@@ -2129,9 +2130,9 @@ func TestMPTInsertABC(t *testing.T) {
 
 func TestMPTDeleteSameEndingPathNode(t *testing.T) {
 	mndb := NewMemoryNodeDB()
-	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil)
+	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil, statecache.NewEmpty())
 	db := NewLevelNodeDB(NewMemoryNodeDB(), mpt.db, false)
-	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), nil)
+	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), nil, statecache.NewEmpty())
 
 	doStrValInsert(t, mpt2, "1245", "1234")
 	doStrValInsert(t, mpt2, "12", "12")
@@ -2143,9 +2144,9 @@ func TestMPTDeleteSameEndingPathNode(t *testing.T) {
 }
 func TestMPTFullToLeafNodeDelete(t *testing.T) {
 	mndb := NewMemoryNodeDB()
-	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil)
+	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil, statecache.NewEmpty())
 	db := NewLevelNodeDB(NewMemoryNodeDB(), mpt.db, false)
-	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), nil)
+	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), nil, statecache.NewEmpty())
 
 	doStrValInsert(t, mpt2, "1245", "1234")
 	doStrValInsert(t, mpt2, "12", "12")
@@ -2157,26 +2158,28 @@ func TestMPTFullToLeafNodeDelete(t *testing.T) {
 
 func TestMPTFindMissingNodes(t *testing.T) {
 	mndb := NewMemoryNodeDB()
-	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil)
+	mpt := NewMerklePatriciaTrie(mndb, Sequence(0), nil, statecache.NewEmpty())
 	db := NewLevelNodeDB(NewMemoryNodeDB(), mpt.db, false)
-	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), nil)
+	mpt2 := NewMerklePatriciaTrie(db, Sequence(0), nil, statecache.NewEmpty())
 
 	doStrValInsert(t, mpt2, "12345897", "earth")
 	doStrValInsert(t, mpt2, "1234", "mars")
 	doStrValInsert(t, mpt2, "123456", "venus")
-	nodes, err := mpt2.GetPathNodes(Path("1234"))
+	_, err := mpt2.GetNodeValueRaw(Path("1234"))
 	require.NoError(t, err)
-	for _, n := range nodes {
-		fmt.Println(n.GetHash())
-	}
 
 	dk, err := fromHex("10ad1e05513ed0e075818d7351d623c05a48dd5c5ebeb6320bd90183fae72fb5")
 	require.NoError(t, err)
 	err = db.DeleteNode(Key(dk))
 	require.NoError(t, err)
 
-	ks, err := mpt2.FindMissingNodesInPath(Path("12345897"))
-	require.NoError(t, err)
+	keys := mpt2.GetMissingNodeKeys()
+	var find bool
+	for _, k := range keys {
+		if bytes.Equal(dk, k) {
+			find = true
+		}
+	}
 
-	require.Equal(t, ToHex(ks[0]), "10ad1e05513ed0e075818d7351d623c05a48dd5c5ebeb6320bd90183fae72fb5")
+	require.True(t, find)
 }

--- a/core/util/mpt_node.go
+++ b/core/util/mpt_node.go
@@ -472,7 +472,7 @@ func (fn *FullNode) CloneNode() Node {
 }
 
 func (fn *FullNode) Clone() statecache.Value {
-	return fn.Clone()
+	return fn.CloneNode()
 }
 
 func (fn *FullNode) CopyFrom(v interface{}) bool {

--- a/core/util/mpt_node.go
+++ b/core/util/mpt_node.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/0chain/common/core/encryption"
 	"github.com/0chain/common/core/logging"
+	"github.com/0chain/common/core/statecache"
 	"go.uber.org/zap"
 )
 
@@ -22,13 +23,13 @@ const (
 	NodeTypesAll          = NodeTypeValueNode | NodeTypeLeafNode | NodeTypeFullNode | NodeTypeExtensionNode
 )
 
-//Separator - used to separate fields when creating data array to hash
+// Separator - used to separate fields when creating data array to hash
 const Separator = ':'
 
-//ErrInvalidEncoding - error to indicate invalid encoding
+// ErrInvalidEncoding - error to indicate invalid encoding
 var ErrInvalidEncoding = errors.New("invalid node encoding")
 
-//PathElements - all the bytes that can be used as path elements as ascii characters
+// PathElements - all the bytes that can be used as path elements as ascii characters
 var PathElements = []byte("0123456789abcdef")
 
 /*Node - a node interface */
@@ -36,25 +37,26 @@ type Node interface {
 	Serializable
 	Hashable
 	OriginTrackerI
-	Clone() Node
+	statecache.Value
+	CloneNode() Node
 	GetNodeType() byte
 	GetOriginTracker() OriginTrackerI
 	SetOriginTracker(ot OriginTrackerI)
 }
 
-//OriginTrackerNode - a node that implements origin tracking
+// OriginTrackerNode - a node that implements origin tracking
 type OriginTrackerNode struct {
 	OriginTracker OriginTrackerI `json:"o,omitempty"`
 }
 
-//NewOriginTrackerNode - create a new origin tracker node
+// NewOriginTrackerNode - create a new origin tracker node
 func NewOriginTrackerNode() *OriginTrackerNode {
 	otn := &OriginTrackerNode{}
 	otn.OriginTracker = &OriginTracker{}
 	return otn
 }
 
-//Clone - clone the given origin tracker node
+// Clone - clone the given origin tracker node
 func (otn *OriginTrackerNode) Clone() *OriginTrackerNode {
 	clone := NewOriginTrackerNode()
 	clone.OriginTracker.SetOrigin(otn.GetOrigin())
@@ -62,42 +64,42 @@ func (otn *OriginTrackerNode) Clone() *OriginTrackerNode {
 	return clone
 }
 
-//SetOriginTracker - implement interface
+// SetOriginTracker - implement interface
 func (otn *OriginTrackerNode) SetOriginTracker(ot OriginTrackerI) {
 	otn.OriginTracker = ot
 }
 
-//SetOrigin - implement interface
+// SetOrigin - implement interface
 func (otn *OriginTrackerNode) SetOrigin(origin Sequence) {
 	otn.OriginTracker.SetOrigin(origin)
 }
 
-//GetOrigin - implement interface
+// GetOrigin - implement interface
 func (otn *OriginTrackerNode) GetOrigin() Sequence {
 	return otn.OriginTracker.GetOrigin()
 }
 
-//SetVersion - implement interface
+// SetVersion - implement interface
 func (otn *OriginTrackerNode) SetVersion(version Sequence) {
 	otn.OriginTracker.SetVersion(version)
 }
 
-//GetVersion - implement interface
+// GetVersion - implement interface
 func (otn *OriginTrackerNode) GetVersion() Sequence {
 	return otn.OriginTracker.GetVersion()
 }
 
-//Write - implement interface
+// Write - implement interface
 func (otn *OriginTrackerNode) Write(w io.Writer) error {
 	return otn.OriginTracker.Write(w)
 }
 
-//Read - implement interface
+// Read - implement interface
 func (otn *OriginTrackerNode) Read(r io.Reader) error {
 	return otn.OriginTracker.Read(r)
 }
 
-//GetOriginTracker - implement interface
+// GetOriginTracker - implement interface
 func (otn *OriginTrackerNode) GetOriginTracker() OriginTrackerI {
 	return otn.OriginTracker
 }
@@ -108,7 +110,7 @@ type ValueNode struct {
 	*OriginTrackerNode `json:"o,omitempty"`
 }
 
-//NewValueNode - create a new value node
+// NewValueNode - create a new value node
 func NewValueNode() *ValueNode {
 	vn := &ValueNode{}
 	vn.OriginTrackerNode = NewOriginTrackerNode()
@@ -116,13 +118,29 @@ func NewValueNode() *ValueNode {
 }
 
 /*Clone - implement interface */
-func (vn *ValueNode) Clone() Node {
+func (vn *ValueNode) CloneNode() Node {
 	clone := NewValueNode()
 	clone.OriginTrackerNode = vn.OriginTrackerNode.Clone()
 	if vn.Value != nil {
 		clone.SetValue(vn.GetValue())
 	}
 	return clone
+}
+
+func (vn *ValueNode) Clone() statecache.Value {
+	return vn.CloneNode()
+}
+
+func (vn *ValueNode) CopyFrom(v interface{}) bool {
+	vv, ok := v.(*ValueNode)
+	if !ok {
+		return false
+	}
+
+	cv := vv.CloneNode().(*ValueNode)
+
+	*vn = *cv
+	return true
 }
 
 /*GetNodeType - implement interface */
@@ -288,7 +306,7 @@ func (ln *LeafNode) Decode(buf []byte) error {
 }
 
 /*Clone - implement interface */
-func (ln *LeafNode) Clone() Node {
+func (ln *LeafNode) CloneNode() Node {
 	clone := &LeafNode{}
 	clone.OriginTrackerNode = ln.OriginTrackerNode.Clone()
 	clone.Prefix = concat(ln.Prefix)
@@ -296,6 +314,22 @@ func (ln *LeafNode) Clone() Node {
 	// path will never be updated inplace and so ok
 	clone.SetValue(ln.GetValue())
 	return clone
+}
+
+func (ln *LeafNode) Clone() statecache.Value {
+	return ln.CloneNode()
+}
+
+func (ln *LeafNode) CopyFrom(v interface{}) bool {
+	vv, ok := v.(*LeafNode)
+	if !ok {
+		return false
+	}
+
+	cv := vv.CloneNode().(*LeafNode)
+
+	*ln = *cv
+	return true
 }
 
 /*GetNodeType - implement interface */
@@ -422,7 +456,7 @@ func (fn *FullNode) Decode(buf []byte) error {
 }
 
 /*Clone - implement interface */
-func (fn *FullNode) Clone() Node {
+func (fn *FullNode) CloneNode() Node {
 	clone := &FullNode{}
 	clone.OriginTrackerNode = fn.OriginTrackerNode.Clone()
 	for idx, ckey := range fn.Children {
@@ -435,6 +469,22 @@ func (fn *FullNode) Clone() Node {
 		clone.SetValue(fn.GetValue())
 	}
 	return clone
+}
+
+func (fn *FullNode) Clone() statecache.Value {
+	return fn.Clone()
+}
+
+func (fn *FullNode) CopyFrom(v interface{}) bool {
+	vv, ok := v.(*FullNode)
+	if !ok {
+		return false
+	}
+
+	cv := vv.CloneNode().(*FullNode)
+
+	*fn = *cv
+	return true
 }
 
 /*GetNodeType - implement interface */
@@ -575,12 +625,28 @@ func (en *ExtensionNode) Decode(buf []byte) error {
 }
 
 /*Clone - implement interface */
-func (en *ExtensionNode) Clone() Node {
+func (en *ExtensionNode) CloneNode() Node {
 	clone := &ExtensionNode{}
 	clone.OriginTrackerNode = en.OriginTrackerNode.Clone()
 	clone.Path = en.Path       // path will never be updated inplace and so ok
 	clone.NodeKey = en.NodeKey // nodekey will never be updated inplace and so ok
 	return clone
+}
+
+func (en *ExtensionNode) Clone() statecache.Value {
+	return en.CloneNode()
+}
+
+func (en *ExtensionNode) CopyFrom(v interface{}) bool {
+	vv, ok := v.(*ExtensionNode)
+	if !ok {
+		return false
+	}
+
+	cv := vv.CloneNode().(*ExtensionNode)
+
+	*en = *cv
+	return true
 }
 
 /*GetNodeType - implement interface */

--- a/core/util/mpt_node_change.go
+++ b/core/util/mpt_node_change.go
@@ -141,7 +141,7 @@ func (cc *ChangeCollector) UpdateChanges(ndb NodeDB, origin Sequence, includeDel
 	nodes := make([]Node, len(cc.Changes))
 	idx := 0
 	for _, c := range cc.Changes {
-		nodes[idx] = c.New.Clone()
+		nodes[idx] = c.New.CloneNode()
 		keys[idx] = nodes[idx].GetHashBytes()
 		keysStr[idx] = nodes[idx].GetHash()
 		idx++
@@ -208,17 +208,17 @@ func (cc *ChangeCollector) Clone() ChangeCollectorI {
 
 	for k, v := range cc.Changes {
 		change := &NodeChange{
-			New: v.New.Clone(),
+			New: v.New.CloneNode(),
 		}
 		if v.Old != nil {
-			change.Old = v.Old.Clone()
+			change.Old = v.Old.CloneNode()
 		}
 
 		c.Changes[k] = change
 	}
 
 	for k, v := range cc.Deletes {
-		c.Deletes[k] = v.Clone()
+		c.Deletes[k] = v.CloneNode()
 	}
 
 	return c

--- a/core/util/mpt_nodedb.go
+++ b/core/util/mpt_nodedb.go
@@ -93,7 +93,7 @@ func (mndb *MemoryNodeDB) getNode(key Key) (Node, error) {
 
 // unsafe
 func (mndb *MemoryNodeDB) putNode(key Key, node Node) error {
-	nd := node.Clone()
+	nd := node.CloneNode()
 	if DebugMPTNode {
 		if !bytes.Equal(key, nd.GetHashBytes()) {
 			logging.Logger.Error("MPT - put node key not match",
@@ -420,7 +420,7 @@ func (lndb *LevelNodeDB) getNode(key Key) (Node, error) {
 
 // unsafe
 func (lndb *LevelNodeDB) putNode(key Key, node Node) error {
-	nd := node.Clone()
+	nd := node.CloneNode()
 	if DebugMPTNode {
 		if !bytes.Equal(key, nd.GetHashBytes()) {
 			logging.Logger.Error("MPT - put node key not match, level node",

--- a/core/util/mpt_nodedb.go
+++ b/core/util/mpt_nodedb.go
@@ -206,14 +206,15 @@ func (mndb *MemoryNodeDB) Size(_ context.Context) int64 {
 
 /*PruneBelowVersion - implement interface */
 func (mndb *MemoryNodeDB) PruneBelowVersion(ctx context.Context, version int64) error {
-	mndb.mutex.Lock()
-	defer mndb.mutex.Unlock()
-	return mndb.iterate(ctx, func(ctx context.Context, key Key, node Node) error {
-		if int64(node.GetVersion()) < version {
-			return mndb.deleteNode(key)
-		}
-		return nil
-	})
+	// mndb.mutex.Lock()
+	// defer mndb.mutex.Unlock()
+	// return mndb.iterate(ctx, func(ctx context.Context, key Key, node Node) error {
+	// 	if int64(node.GetVersion()) < version {
+	// 		return mndb.deleteNode(key)
+	// 	}
+	// 	return nil
+	// })
+	return nil
 }
 
 func (mndb *MemoryNodeDB) RecordDeadNodes([]Node, int64) error {

--- a/core/util/mpt_nodedb_test.go
+++ b/core/util/mpt_nodedb_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/0chain/common/core/statecache"
 	"github.com/linxGnu/grocksdb"
 	"github.com/stretchr/testify/require"
 )
@@ -1224,7 +1225,7 @@ func TestMemoryNodeDB_Validate(t *testing.T) {
 			name: "TestMemoryNodeDB_Validate_ERR",
 			fields: func() fields {
 				mndb := NewMemoryNodeDB()
-				mpt := NewMerklePatriciaTrie(mndb, 1, nil)
+				mpt := NewMerklePatriciaTrie(mndb, 1, nil, statecache.NewEmpty())
 
 				n := &AState{balance: 2}
 				_, err := mpt.Insert(Path("astate_2"), n)

--- a/core/util/mpt_pnodedb.go
+++ b/core/util/mpt_pnodedb.go
@@ -144,7 +144,7 @@ func (pndb *PNodeDB) GetNode(key Key) (Node, error) {
 
 /*PutNode - implement interface */
 func (pndb *PNodeDB) PutNode(key Key, node Node) error {
-	nd := node.Clone()
+	nd := node.CloneNode()
 	data := nd.Encode()
 	if DebugMPTNode && !bytes.Equal(key, nd.GetHashBytes()) {
 		logging.Logger.Error("put node key not match",
@@ -362,7 +362,7 @@ func (pndb *PNodeDB) MultiPutNode(keys []Key, nodes []Node) error {
 	wb := grocksdb.NewWriteBatch()
 	defer wb.Destroy()
 	for idx, key := range keys {
-		nd := nodes[idx].Clone()
+		nd := nodes[idx].CloneNode()
 		if !bytes.Equal(key, nd.GetHashBytes()) {
 			logging.Logger.Error("put node key not match",
 				zap.String("key", ToHex(key)),

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/0chain/common
 go 1.18
 
 require (
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/linxGnu/grocksdb v1.8.0
 	github.com/shopspring/decimal v1.3.1
 	github.com/spf13/cast v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=


### PR DESCRIPTION
Add MPT cache.

There are mainly 3 levels caches: State level cache, Block level cache and Transaction level cache. We use the https://github.com/hashicorp/golang-lru as the caches, so when the cache is full, the last recently used cached values will be removed automatically. 

## Transaction level cache
The Transaction level cache is created on each transaction, means it's fresh and empty before every transaction is executed.  It stores all the updated MPT key/values nodes that happened in a transaction, and all will be committed to the Block level cache after the transaction is done. When executing SC, for any cacheable (any value that implemented the [statecache.Value](https://github.com//0chain/common/blob/feature/mpt-cache/core/statecache/statecache.go#L20-L23) interface) MPT nodes, we will firstly try to load from the transaction level cache, if not find, then try to get it from Block level cache, if still not found, we will try to get it from the State level cache. See details of how State level cache works below. 

## Block level cache
Block level cache stores all the changes that happened in all the transactions in the block, and they will all be committed to the global State level cache once the block state computation is done. 

## State level cache
The State level cache is the global MPT cache that stores all the cached key/value pairs that happened in all blocks. The state cache is mainly constructed of 2 parts: a) cache that stores the key/value, b) chain hashes that stores the block hash as key and its previous block hash as value. 

The a) cache stores any value that we want to cache,  the value is another cache map that stores the values under the key that are updated in different blocks, the block hash is the key of the cache map. When we try to get a value from the state cache, we need to firstly get the cache map of the key from the global state, then get the value of given block hash.  Anyway, we usually don't get value from the global state directly, instead we get from Block level cache or transaction level cache. 

The b) chain hashes forms the chains, it is useful when we try to get values that is not updated in every block. So if the value is neither in transaction level cache, nor in block level cache, we will try to get it from the state level cache. The getting process is like: get the value of the key of `Block level cache.previous_block` first, if find then return the value. Otherwise we need to check if its in previous blocks. And by accessing the b) chain hashes cache, we can know the previous block. We will get back till the max depth (100 rounds, cause miners only store 100 blocks general) is encountered or no previous block is find (means a gap happened), or find the value of course. 

