### PR TITLE
fix(wmpt): register collapsed routing node on createdChan (prevents dangling prune)

### DIFF
--- a/core/util/wmpt/trie.go
+++ b/core/util/wmpt/trie.go
@@ -484,6 +484,13 @@ func (t *WeightedMerkleTrie) commit(node Node, batcher storage.Batcher, collapse
 			return nil, err
 		}
 		if level == collapseLevel {
+			// The collapsed node was just Save()d to the batch, so it lives in
+			// the new trie under this hash. It MUST be registered as created so
+			// (1) collectDeleteAndCreated removes it from the pending-delete set
+			// (a deferred DeleteNodes() would otherwise prune a node the new root
+			// still references -> dangling "pebble: not found"), and (2) it is
+			// cleaned up on Rollback like every other node written this commit.
+			createdChan <- n.Hash()
 			n.Children = [16]Node{}
 			return &hashNode{
 				hash:   n.Hash(),

--- a/core/util/wmpt/trie_test.go
+++ b/core/util/wmpt/trie_test.go
@@ -139,6 +139,73 @@ func TestTrieCommit(t *testing.T) {
 	assert.Equal(t, trie.root.CalcHash(), dbTrie.root.Hash())
 }
 
+// TestCommitCollapsePruneDangling guards against the dangling-node bug where a
+// routing node collapsed at collapseLevel was Save()d but never registered on
+// createdChan. A node whose hash was queued for deletion in an earlier commit
+// (delete) and then re-appears at the collapse boundary in a later commit
+// (re-add) would be pruned by the deferred DeleteNodes() while the new root
+// still references it -> reloading and GetPath hits "pebble: not found".
+// Delete/re-add churn shifts tree depth around COLLAPSE_DEPTH and triggers it.
+func TestCommitCollapsePruneDangling(t *testing.T) {
+	const (
+		N        = 40
+		collapse = 2 // mirrors a shallow COLLAPSE_DEPTH so boundary is hit often
+	)
+	keys := make([][]byte, N)
+	for i := 0; i < N; i++ {
+		h := sha256.Sum256([]byte("collapse-" + strconv.Itoa(i)))
+		// Force a shared 2-byte prefix so all keys live under a deep common
+		// path; the random sha256 tail then branches into a multi-level trie.
+		h[0], h[1] = 0xAB, 0xCD
+		keys[i] = h[:]
+	}
+
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+	pebDir := filepath.Join(wd, "pebble_storage_collapse")
+	assert.NoError(t, os.RemoveAll(pebDir))
+	assert.NoError(t, os.MkdirAll(pebDir, 0777))
+	db, err := kv.NewPebbleAdapter(pebDir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		db.Close()
+		os.RemoveAll(pebDir)
+	}()
+
+	trie := New(nil, db)
+	val := func(i int) []byte { return []byte("v" + strconv.Itoa(i)) }
+	for i := 0; i < N; i++ {
+		assert.NoError(t, trie.Update(keys[i], val(i), uint64(i+1)))
+	}
+	commit := func() {
+		trie.SaveRoot()
+		batcher, cerr := trie.Commit(collapse)
+		assert.NoError(t, cerr)
+		assert.NoError(t, batcher.Commit(true))
+		assert.NoError(t, trie.DeleteNodes())
+	}
+	commit()
+
+	// After each round all N keys are present; reload from the persisted root
+	// and prove every path resolves (no pruned/dangling node).
+	checkIntact := func(round int) {
+		reloaded := New(&hashNode{hash: trie.Root(), weight: trie.GetRoot().Weight()}, db)
+		_, perr := reloaded.GetPath(keys)
+		assert.NoErrorf(t, perr, "round %d: GetPath hit a pruned collapsed node", round)
+	}
+
+	for round := 0; round < N; round++ {
+		i := round
+		assert.NoError(t, trie.Update(keys[i], nil, 0)) // delete -> hash queued for deferred delete
+		commit()
+		assert.NoError(t, trie.Update(keys[i], val(i), uint64(i+1))) // re-add -> may re-appear at boundary
+		commit()
+		checkIntact(round)
+	}
+}
+
 func TestRollbackTrie(t *testing.T) {
 	keys := make([][]byte, 0, 5)
 	for i := 0; i < 5; i++ {


### PR DESCRIPTION
Collapsed routing node at collapseLevel was Save()d but never sent to createdChan, so collectDeleteAndCreated couldn't drop it from the deferred-delete set; DeleteNodes() then pruned a node the new root still references -> 'pebble: not found' on GetPath/referencepath after delete churn (StorageV2 blobbers). One-line fix + regression test TestCommitCollapsePruneDangling (fails pre-fix, passes post-fix). Diagnosis: 0chain/blobber docs/wmpt-collapse-prune-dangling.md.